### PR TITLE
EPIC #1541 T2.4: migration-ready xtrax dispatch adapter (not yet wired)

### DIFF
--- a/src/aminx/tiling/dispatch.py
+++ b/src/aminx/tiling/dispatch.py
@@ -6,8 +6,18 @@ for invalid axis/strategy pairs. Part of the composable_jax library surface.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aminx.tiling.errors import TilingError
 from aminx.tiling.strategy import AxisStrategy, SafeMap, Scan, Vmap
+
+if TYPE_CHECKING:
+  # Type-check-only: satisfies ty without a runtime top-level xtrax import
+  # (the actual imports below stay lazy/function-local, matching this file's
+  # existing circular-import-avoidance convention for aminx.tiling.iterator).
+  from xtrax.tiling import SafeMap as XtraxSafeMap
+  from xtrax.tiling import Scan as XtraxScan
+  from xtrax.tiling import Vmap as XtraxVmap
 
 
 class DispatchRejected(TilingError):
@@ -86,4 +96,96 @@ def make_axis_dispatch(strategy: AxisStrategy, *, axis: str = "state") -> object
   raise TypeError(f"Unknown strategy type: {type(strategy)}")
 
 
-__all__ = ["DispatchRejected", "make_axis_dispatch"]
+# Axis names make_axis_dispatch currently treats as heterogeneous (hardcoded
+# as a literal "state" check above). Kept as an explicit constant here, not
+# reused from tiling/carry.py's _HETEROGENEOUS_AXIS_NAMES ({"n_states",
+# "n_structures"}), since that constant serves a different naming context
+# (CarrySpec) and has never been shown to mean the same thing as this one.
+_DISPATCH_HETEROGENEOUS_AXES = frozenset({"state"})
+
+
+def _strategy_to_xtrax(strategy: AxisStrategy) -> XtraxVmap | XtraxSafeMap | XtraxScan:
+  """Translate an aminx-native AxisStrategy into its xtrax-native equivalent.
+
+  aminx's and xtrax's Vmap/SafeMap/Scan classes are structurally similar but
+  are NOT the same classes (xtrax's `isinstance` checks are against its own
+  classes) -- an aminx-native strategy instance is not a valid argument to
+  xtrax.tiling.dispatch.make_axis_dispatch without this translation. See
+  tests/tiling/test_t2_4_xtrax_dispatch_compat.py for the empirical finding.
+  """
+  from xtrax.tiling import SafeMap as _XtraxSafeMap
+  from xtrax.tiling import Scan as _XtraxScan
+  from xtrax.tiling import Vmap as _XtraxVmap
+
+  if isinstance(strategy, Vmap):
+    return _XtraxVmap()
+  if isinstance(strategy, SafeMap):
+    return _XtraxSafeMap(batch_size=strategy.tile)
+  if isinstance(strategy, Scan):
+    return _XtraxScan(
+      transition=strategy.transition,
+      init=strategy.init,
+      ordered_sinks=strategy.ordered_sinks,
+    )
+  raise TypeError(f"Unknown strategy type: {type(strategy)}")
+
+
+def make_axis_dispatch_via_xtrax(strategy: AxisStrategy, *, axis: str = "state") -> object:
+  """T2.4 migration target: make_axis_dispatch, backed by xtrax.tiling.dispatch.
+
+  EPIC #1541 (aminx.tiling -> xtrax.tiling migration,
+  `.praxia/docs/specs/260611_aminx-xtrax-refactor.md`, T-FACTORY-HOME row).
+  Mirrors `make_axis_dispatch`'s exact contract (same accepted/rejected
+  strategy-axis pairs, same DispatchRejected/TilingError hierarchy, same
+  returned-iterator call shape) while delegating iterator construction to
+  xtrax. Not yet wired into any call site -- `factory.py` and friends still
+  import `make_axis_dispatch` above. This is the flip target once T2.GATE
+  (bit-for-bit parity + recompile-count tripwire + cluster throughput bench)
+  passes; see tests/tiling/test_dispatch_via_xtrax_parity.py for the parity
+  suite this function must keep matching.
+
+  Two adaptations `make_axis_dispatch` doesn't need, both proven empirically
+  in tests/tiling/test_t2_4_xtrax_dispatch_compat.py:
+  1. Strategy objects are translated via `_strategy_to_xtrax` first --
+     aminx-native and xtrax-native Vmap/SafeMap/Scan are distinct classes.
+  2. `heterogeneous_axes` is passed explicitly to xtrax's make_axis_dispatch
+     (it defaults to none rejected, unlike aminx's hardcoded axis=="state"
+     check) -- forgetting this would silently stop rejecting Scan-on-state.
+
+  Raises
+  ------
+  DispatchRejected
+      Same conditions as make_axis_dispatch (Scan on a heterogeneous axis,
+      or DedupGather). Always aminx's own DispatchRejected (a TilingError
+      subclass) -- xtrax's DispatchRejected (a plain Exception, not a
+      TilingError) is caught and translated at this boundary, the same
+      pattern `host/plan.py:_validate_plan_topology` already uses for
+      PlanTopologyError.
+
+  """
+  from xtrax.tiling import DispatchRejected as _XtraxDispatchRejected
+  from xtrax.tiling import make_axis_dispatch as _xtrax_make_axis_dispatch
+
+  from aminx.tiling.strategy import DedupGather
+
+  # Reject DedupGather up front (same message/exception as make_axis_dispatch;
+  # no need to even translate the strategy for a path that always rejects).
+  if isinstance(strategy, DedupGather):
+    raise DispatchRejected(
+      "DedupGather strategy is handled by _dispatch_axis in kernel_dispatch.py, "
+      "not by make_axis_dispatch (which maps to iterator types). "
+      "Use DedupGather via BatchPlanner + _dispatch_axis, not make_axis_dispatch.",
+    )
+
+  xtrax_strategy = _strategy_to_xtrax(strategy)
+  try:
+    return _xtrax_make_axis_dispatch(
+      xtrax_strategy,
+      axis=axis,
+      heterogeneous_axes=set(_DISPATCH_HETEROGENEOUS_AXES),
+    )
+  except _XtraxDispatchRejected as exc:
+    raise DispatchRejected(str(exc)) from exc
+
+
+__all__ = ["DispatchRejected", "make_axis_dispatch", "make_axis_dispatch_via_xtrax"]

--- a/tests/tiling/test_dispatch_via_xtrax_parity.py
+++ b/tests/tiling/test_dispatch_via_xtrax_parity.py
@@ -1,0 +1,115 @@
+"""Parity suite for make_axis_dispatch_via_xtrax vs make_axis_dispatch.
+
+EPIC #1541 / T2.4 (`.praxia/docs/specs/260611_aminx-xtrax-refactor.md`).
+Mirrors tests/tiling/test_dispatch.py's assertions exactly, but against the
+xtrax-backed `make_axis_dispatch_via_xtrax`, plus direct side-by-side checks.
+This is the shadow-parity evidence for flipping `factory.py` (and friends)
+from `make_axis_dispatch` to `make_axis_dispatch_via_xtrax` once T2.GATE
+passes -- if this suite passes, the xtrax-backed path is behaviorally
+indistinguishable from the current one for every case the original suite
+covers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aminx.host.plan import PlanTopologyError
+from aminx.tiling.dispatch import (
+    DispatchRejected,
+    make_axis_dispatch,
+    make_axis_dispatch_via_xtrax,
+)
+from aminx.tiling.errors import TilingError
+from aminx.tiling.strategy import DedupGather, SafeMap, Scan, Vmap
+
+
+class TestMakeAxisDispatchViaXtraxHappyPath:
+    """Mirrors TestMakeAxisDispatchHappyPath in test_dispatch.py."""
+
+    def test_vmap_dispatch_returns_vmap_iterator(self) -> None:
+        result = make_axis_dispatch_via_xtrax(Vmap())
+        assert result is not None
+        assert type(result).__name__ == "VmapIterator"
+
+    def test_safemap_dispatch_returns_safemap_iterator(self) -> None:
+        result = make_axis_dispatch_via_xtrax(SafeMap(tile=4))
+        assert result is not None
+        assert type(result).__name__ == "SafeMapIterator"
+        assert result.tile == 4
+
+
+class TestMakeAxisDispatchViaXtraxRejectPath:
+    """Mirrors TestMakeAxisDispatchRejectPath in test_dispatch.py."""
+
+    def test_scan_on_state_axis_raises_dispatch_rejected(self) -> None:
+        scan_strategy = Scan(init=0, transition=lambda c, x: (c, x))
+
+        with pytest.raises(DispatchRejected) as exc_info:
+            make_axis_dispatch_via_xtrax(scan_strategy, axis="state")
+
+        error_msg = str(exc_info.value)
+        assert "state axis" in error_msg.lower()
+        assert "heterogeneous" in error_msg.lower()
+
+    def test_dispatch_rejected_is_still_a_tilingerror(self) -> None:
+        """The translated exception (aminx's own DispatchRejected) preserves
+        the TilingError contract -- callers doing `except TilingError` keep
+        working even though xtrax's own DispatchRejected does not subclass it.
+        """
+        assert issubclass(DispatchRejected, TilingError)
+        assert issubclass(PlanTopologyError, TilingError)
+
+    def test_make_axis_dispatch_via_xtrax_rejects_dedup_gather(self) -> None:
+        dg = DedupGather(
+            unique_indices=np.array([0, 1], dtype=np.int32),
+            index_map=np.array([0, 1, 0, 1], dtype=np.int32),
+            k=2,
+            k_bucket=2,
+        )
+        with pytest.raises(DispatchRejected):
+            make_axis_dispatch_via_xtrax(dg)
+
+
+class TestSideBySideParity:
+    """Direct comparison: same input, same observable outcome, both paths."""
+
+    def test_vmap_produces_same_iterator_type_on_both_paths(self) -> None:
+        legacy = make_axis_dispatch(Vmap())
+        via_xtrax = make_axis_dispatch_via_xtrax(Vmap())
+        assert type(legacy).__name__ == type(via_xtrax).__name__ == "VmapIterator"
+
+    def test_safemap_produces_same_tile_value_on_both_paths(self) -> None:
+        legacy = make_axis_dispatch(SafeMap(tile=7))
+        via_xtrax = make_axis_dispatch_via_xtrax(SafeMap(tile=7))
+        assert legacy.tile == via_xtrax.tile == 7
+
+    def test_scan_on_state_rejected_on_both_paths(self) -> None:
+        scan_strategy = Scan(init=0, transition=lambda c, x: (c, x))
+        with pytest.raises(DispatchRejected):
+            make_axis_dispatch(scan_strategy, axis="state")
+        with pytest.raises(DispatchRejected):
+            make_axis_dispatch_via_xtrax(scan_strategy, axis="state")
+
+    def test_scan_on_non_state_axis_accepted_on_both_paths(self) -> None:
+        """Confirms the heterogeneous_axes translation covers the non-rejection
+        case too, not just the rejection case -- Scan on a non-heterogeneous
+        axis must be accepted on both paths, not just "doesn't crash."
+        """
+        scan_strategy = Scan(init=0, transition=lambda c, x: (c, x))
+        legacy = make_axis_dispatch(scan_strategy, axis="wave")
+        via_xtrax = make_axis_dispatch_via_xtrax(scan_strategy, axis="wave")
+        assert type(legacy).__name__ == type(via_xtrax).__name__ == "JaxScanIterator"
+
+    def test_dedup_gather_rejected_on_both_paths(self) -> None:
+        dg = DedupGather(
+            unique_indices=np.array([0, 1], dtype=np.int32),
+            index_map=np.array([0, 1, 0, 1], dtype=np.int32),
+            k=2,
+            k_bucket=2,
+        )
+        with pytest.raises(DispatchRejected):
+            make_axis_dispatch(dg)
+        with pytest.raises(DispatchRejected):
+            make_axis_dispatch_via_xtrax(dg)

--- a/tests/tiling/test_t2_4_xtrax_dispatch_compat.py
+++ b/tests/tiling/test_t2_4_xtrax_dispatch_compat.py
@@ -1,0 +1,127 @@
+"""EPIC #1541 / T2.4 migration-readiness probe: aminx.tiling.dispatch vs xtrax.tiling.dispatch.
+
+Not a production test -- this verifies (empirically, not by spec-reading) whether
+aminx's `inference/decode/factory.py` wrapper pattern would keep working if its
+`from aminx.tiling.dispatch import ...` import were repointed to
+`xtrax.tiling.dispatch`, per the migration invariants listed in
+`.praxia/docs/specs/260611_aminx-xtrax-refactor.md` (T-FACTORY-HOME row).
+
+Findings so far (see test docstrings below):
+  - SafeMap field name differs (aminx: `.tile`, xtrax: `.batch_size`) -- an
+    aminx-native SafeMap instance is NOT a drop-in argument to xtrax's
+    make_axis_dispatch.
+  - xtrax's heterogeneous-axis rejection is caller-supplied (`heterogeneous_axes`
+    kwarg), not hardcoded like aminx's `axis == "state"` check -- a naive import
+    swap without updating call sites to pass `heterogeneous_axes={"state"}`
+    would silently stop rejecting Scan-on-state instead of raising.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+from aminx.tiling.strategy import SafeMap as AminxSafeMap
+from aminx.tiling.strategy import Scan as AminxScan
+from aminx.tiling.strategy import Vmap as AminxVmap
+from xtrax.tiling.dispatch import DispatchRejected as XtraxDispatchRejected
+from xtrax.tiling.dispatch import make_axis_dispatch as xtrax_make_axis_dispatch
+from xtrax.tiling.strategy import SafeMap as XtraxSafeMap
+from xtrax.tiling.strategy import Scan as XtraxScan
+from xtrax.tiling.strategy import Vmap as XtraxVmap
+
+
+def test_aminx_native_safemap_is_not_drop_in_for_xtrax_dispatch():
+    """aminx's SafeMap and xtrax's SafeMap are unrelated classes (not just a
+    field-name mismatch) -- xtrax's `isinstance(strategy, SafeMap)` check
+    (against ITS OWN SafeMap class) is False for an aminx-native SafeMap
+    instance, so it falls through every branch to the exhaustiveness TypeError.
+
+    A naive import-swap migration (repoint `from aminx.tiling.dispatch import
+    make_axis_dispatch` to xtrax's, leave strategy construction untouched) fails
+    loudly at the first SafeMap call site -- not silently -- but it means the
+    dispatch layer cannot migrate independently of the strategy-construction
+    layer (BatchPlanner) without an adapter that translates aminx-native
+    strategy instances into xtrax-native ones first.
+    """
+    aminx_strategy = AminxSafeMap(tile=4)
+    with pytest.raises(TypeError, match="Unknown strategy type"):
+        xtrax_make_axis_dispatch(aminx_strategy, axis="state")
+
+
+def test_xtrax_native_safemap_works_fine_via_xtrax_dispatch():
+    """Sanity check: xtrax's own SafeMap is of course a valid argument."""
+    xtrax_strategy = XtraxSafeMap(batch_size=4)
+    iterator = xtrax_make_axis_dispatch(xtrax_strategy, axis="state")
+    assert type(iterator).__name__ == "SafeMapIterator"
+
+
+def test_xtrax_dispatch_does_not_reject_scan_on_state_by_default():
+    """SILENT REGRESSION RISK: without passing heterogeneous_axes explicitly,
+    xtrax's make_axis_dispatch does NOT reject Scan on the state axis -- unlike
+    aminx's dispatch.py, which hardcodes `if axis == "state": raise
+    DispatchRejected(...)` unconditionally. A call-site migration that forgets
+    to pass `heterogeneous_axes={"state"}` would silently accept an invalid
+    Scan-on-state strategy instead of erroring, exactly the kind of gap
+    T2.GATE's parity fixtures need to catch.
+    """
+    strategy = XtraxScan()
+    # No heterogeneous_axes passed -- default is None -> empty set.
+    iterator = xtrax_make_axis_dispatch(strategy, axis="state")
+    assert type(iterator).__name__ == "JaxScanIterator"  # did NOT raise
+
+
+def test_xtrax_dispatch_rejects_scan_on_state_when_heterogeneous_axes_passed():
+    """Confirms the fix: callers must pass heterogeneous_axes explicitly."""
+    strategy = XtraxScan()
+    with pytest.raises(XtraxDispatchRejected, match="heterogeneous"):
+        xtrax_make_axis_dispatch(strategy, axis="state", heterogeneous_axes={"state"})
+
+
+def test_xtrax_dispatch_rejected_exception_is_not_a_tilingerror():
+    """aminx's DispatchRejected subclasses TilingError (so `except TilingError`
+    catches it); xtrax's DispatchRejected subclasses plain Exception. A call
+    site catching aminx's TilingError broadly (not just DispatchRejected) would
+    NOT catch xtrax's DispatchRejected after a naive migration -- the same class
+    of problem `host/plan.py:_validate_plan_topology` already solved for
+    PlanTopologyError by translating xtrax's exception into aminx's own
+    TilingError subclass at the boundary. The same translation pattern would be
+    needed here.
+    """
+    from aminx.tiling.errors import TilingError
+
+    assert not issubclass(XtraxDispatchRejected, TilingError)
+
+
+def test_xtrax_vmap_iterator_call_shape_matches_aminx_expectation():
+    """Confirms invariant: state_iterator(fn, inputs, in_axes=0) returns `ys`
+    only (not a (final_carry, ys) tuple), matching the call pattern used at
+    aminx/inference/decode/{autoregressive,conditional,unconditional}.py.
+    """
+    iterator = xtrax_make_axis_dispatch(XtraxVmap(), axis="state")
+
+    def per_state_fn(x):
+        return x * 2
+
+    inputs = jnp.arange(4.0)
+    result = iterator(per_state_fn, inputs, in_axes=0)
+    assert result.shape == (4,)  # not a tuple -- ys only, matching MapIterator contract
+
+
+def test_xtrax_iterator_is_usable_as_eqx_module_field():
+    """Confirms invariant: the returned iterator can live as a field on an
+    existing aminx eqx.Module (mirroring ConditionalDecode/UnconditionalDecode/
+    AutoregressiveDecode, which declare `state_iterator: MapIterator` as an
+    injected eqx.Module field) without breaking PyTree flatten/unflatten.
+    """
+
+    class _Probe(eqx.Module):
+        state_iterator: object
+
+    iterator = xtrax_make_axis_dispatch(XtraxVmap(), axis="state")
+    probe = _Probe(state_iterator=iterator)
+    leaves, treedef = jax.tree_util.tree_flatten(probe)
+    rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+    assert type(rebuilt.state_iterator).__name__ == "VmapIterator"


### PR DESCRIPTION
## Summary
Part of scoping/de-risking EPIC #1541 (aminx.tiling → xtrax.tiling migration, tracked in the consolidated cross-project roadmap). Not a production behavior change -- `factory.py` and all real call sites still use `make_axis_dispatch` (aminx-native). This PR only adds the migration-ready replacement, empirically verified against xtrax, not yet wired anywhere.

- `tests/tiling/test_t2_4_xtrax_dispatch_compat.py`: migration-readiness probe. Confirms 2 of the spec's 4 T2.4 invariants (eqx.Module-ness, iterator call-shape) hold with zero changes needed against `xtrax.tiling.dispatch`. Surfaces two real gaps: aminx's and xtrax's `SafeMap`/`Vmap`/`Scan` are distinct classes (not just a `tile`/`batch_size` field-name mismatch), and xtrax's heterogeneous-axis rejection is caller-supplied (`heterogeneous_axes` kwarg) vs aminx's hardcoded `axis=="state"` check -- a naive migration that forgets to pass it would silently stop rejecting `Scan`-on-`state`.
- `src/aminx/tiling/dispatch.py`: adds `make_axis_dispatch_via_xtrax`, a drop-in replacement that translates strategy objects, passes `heterogeneous_axes` explicitly, and translates xtrax's `DispatchRejected` (plain `Exception`) into aminx's own (a `TilingError` subclass) at the boundary -- mirroring the pattern `host/plan.py:_validate_plan_topology` already established in production for `PlanTopologyError`.
- `tests/tiling/test_dispatch_via_xtrax_parity.py`: 10-test parity suite mirroring `test_dispatch.py`'s exact assertions plus direct side-by-side checks against the legacy path.

Next gate before wiring this in anywhere: T2.GATE (bit-for-bit golden tiling-parity fixture, JIT-recompile-count tripwire, cluster throughput bench) -- tracked separately in the roadmap, not part of this PR.

## Test plan
- [x] New parity suite (10 tests) passes
- [x] New migration-readiness probe (7 tests) passes
- [x] Full test suite: 1421 passed, 0 failed
- [x] `ty check` passes clean on the modified file
- [x] `ruff check` -- the actively-enforced boundary-lint rule (banned deep-submodule xtrax imports) is clean; remaining findings are pre-existing debt on untouched lines or match this file's own established lazy-import convention (ty/ruff aren't CI gates yet per `.praxia/docs/adr/260604_defer-ty-ruff-ci-gates.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyj9MgkHjdgL7ktrTTpH8w