### PR TITLE
EPIC #1541 T2.GATE: cluster GPU throughput bench -- PASS

### DIFF
--- a/outputs/results/xtrax_vs_aminx_dispatch_gpu.json
+++ b/outputs/results/xtrax_vs_aminx_dispatch_gpu.json
@@ -1,0 +1,67 @@
+{
+  "cases": [
+    {
+      "num_states": 1,
+      "seq_len": 208,
+      "strategy": "SafeMap",
+      "legacy_recompiles": 1,
+      "adapter_recompiles": 1,
+      "recompile_parity": true,
+      "legacy_mean_s": 7.509734947234392e-05,
+      "legacy_stderr_s": 4.623648108831165e-07,
+      "adapter_mean_s": 7.385356351733208e-05,
+      "adapter_stderr_s": 5.213506466355637e-07,
+      "adapter_vs_legacy_throughput_ratio": 0.9834376850348109,
+      "n_warmup": 10,
+      "n_timed": 50
+    },
+    {
+      "num_states": 8,
+      "seq_len": 208,
+      "strategy": "SafeMap",
+      "legacy_recompiles": 1,
+      "adapter_recompiles": 1,
+      "recompile_parity": true,
+      "legacy_mean_s": 0.00015730125829577446,
+      "legacy_stderr_s": 6.579384914232749e-07,
+      "adapter_mean_s": 0.00015758778899908066,
+      "adapter_stderr_s": 7.492134270145604e-07,
+      "adapter_vs_legacy_throughput_ratio": 1.0018215410760887,
+      "n_warmup": 10,
+      "n_timed": 50
+    },
+    {
+      "num_states": 32,
+      "seq_len": 208,
+      "strategy": "SafeMap",
+      "legacy_recompiles": 1,
+      "adapter_recompiles": 1,
+      "recompile_parity": true,
+      "legacy_mean_s": 0.00027112120762467384,
+      "legacy_stderr_s": 5.573881887796457e-07,
+      "adapter_mean_s": 0.00026726248674094675,
+      "adapter_stderr_s": 5.36172428963522e-07,
+      "adapter_vs_legacy_throughput_ratio": 0.9857675431681135,
+      "n_warmup": 10,
+      "n_timed": 50
+    },
+    {
+      "num_states": 128,
+      "seq_len": 208,
+      "strategy": "SafeMap",
+      "legacy_recompiles": 1,
+      "adapter_recompiles": 1,
+      "recompile_parity": true,
+      "legacy_mean_s": 0.0008821934880688787,
+      "legacy_stderr_s": 5.243836438917953e-07,
+      "adapter_mean_s": 0.0008813844714313745,
+      "adapter_stderr_s": 5.097640321558265e-07,
+      "adapter_vs_legacy_throughput_ratio": 0.9990829487539348,
+      "n_warmup": 10,
+      "n_timed": 50
+    }
+  ],
+  "all_recompile_parity": true,
+  "max_adapter_vs_legacy_throughput_ratio": 1.0018215410760887,
+  "device": "[CudaDevice(id=0)]"
+}

--- a/scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.bth.toml
+++ b/scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.bth.toml
@@ -1,0 +1,33 @@
+[experiment]
+hypothesis = "On production-representative GPU shapes (L=208, TEV protease scale), T2.4's make_axis_dispatch_via_xtrax adapter reproduces legacy make_axis_dispatch's recompile behavior bit-for-bit, with throughput overhead within 1.10x"
+stage_name = "confirmation"
+novel = false
+task_id = "260630_wave-color-xtrax-audit"
+
+[outcomes.pass]
+condition = "all_recompile_parity = true AND max_adapter_vs_legacy_throughput_ratio <= 1.10"
+decision = "T2.GATE clears on real GPU/production-shape evidence; the flip from make_axis_dispatch to make_axis_dispatch_via_xtrax is justified for factory.py and friends"
+reasoning = "T2.GATE's stated DoD threshold on the standing cluster gate: identical recompile counts, throughput within 10% overhead, measured on production-representative shapes rather than CPU-synthetic toy functions"
+is_residual = false
+
+[outcomes.marginal]
+condition = "all_recompile_parity = true AND max_adapter_vs_legacy_throughput_ratio <= 1.50"
+decision = "Recompile correctness holds on real shapes but overhead exceeds the strict threshold; investigate xtrax's iterator wrapping cost at production batch sizes before flipping any call site"
+reasoning = "Recompile parity is the correctness claim and it holds; throughput overhead in (10%, 50%] means the adapter is usable but not free -- worth understanding before committing production call sites to it"
+is_residual = false
+
+[outcomes.fail]
+condition = "all_recompile_parity = false OR max_adapter_vs_legacy_throughput_ratio > 1.50"
+decision = "Do not flip factory.py to make_axis_dispatch_via_xtrax on production shapes; either recompile behavior diverges on real workloads (breaks aminx's no-retrace guarantees) or overhead is too large to justify the migration as currently scoped"
+reasoning = "Either recompile behavior diverges under real production shapes (not caught by the CPU-synthetic bench, which only tested toy cardinalities up to 256) or throughput overhead is unacceptable"
+is_residual = true
+
+[result_schema]
+all_recompile_parity = "bool"
+max_adapter_vs_legacy_throughput_ratio = "float"
+
+[result_schema.provenance]
+script_commit = "git log --oneline -1"
+related_epic = "#1541 (aminx->xtrax refactor), gate #1556 (T2.GATE)"
+hardware_targets = ["GPU (mit_preemptable, myxcel preempt-gpu preset)"]
+notes = "Companion to scripts/benchmarks/bench_xtrax_vs_aminx_tiling.py (CPU synthetic toy-function bench, decision+recompile parity only -- its own throughput measurement was found non-reproducible at microsecond scale across 5 repeat runs, 1.03x-1.79x spread). This script is the standing production-shape throughput gate the spec's premortem calls for -- L=208 (TEV protease, 1LVB.cif chain A) synthetic-geometry-at-real-size, num_states swept [1, 8, 32, 128]. L1 (dry-run) + L2 (local CPU smoke, <60s) passed before any cluster submission per CLUSTER.md."

--- a/scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.py
+++ b/scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Cluster GPU throughput bench: legacy dispatch vs T2.4's xtrax adapter.
+
+EPIC #1541 / T2.GATE (#1556, `.praxia/docs/specs/260611_aminx-xtrax-refactor.md`).
+The synthetic CPU microbenchmark (bench_xtrax_vs_aminx_tiling.py) confirmed
+decision-parity and recompile-parity are 100% reproducible, but found its own
+throughput measurement is NOT reproducible at microsecond scale (1.03x-1.79x
+across identical repeated runs -- pure CPU timing noise, not signal). This
+script is the actual T2.GATE throughput requirement: real GPU hardware,
+production-representative shapes, enough repeats for a statistically stable
+estimate.
+
+Production-representative shape: L=208 (TEV protease, 1LVB.cif chain A --
+the real structure already used and validated for this project's W1a.1
+confirmatory campaign), synthetic random geometry (this benchmark measures
+dispatch/tiling overhead, not model biological correctness, so synthetic
+coordinates at a real production SIZE are sufficient -- no need to parse a
+real CIF file). Batch-size (num_states) sweep spans a realistic range; the
+necklace campaign's own (states x models x replicates x candidates) grid
+does not yet fix concrete R/C values (still symbolic in the prereg), so this
+sweeps a representative range rather than one pinned number.
+
+Runs an actual ConditionalDecode call (same pattern as
+tests/tiling/test_t2_gate_bitforbit_golden.py's bit-for-bit check, but timed
+for throughput instead of checked for exact equality) through legacy
+make_axis_dispatch vs T2.4's make_axis_dispatch_via_xtrax, on the identical
+aminx-native strategy decision.
+
+Per the spec's own premortem, this must be a STANDING gate re-run on the
+production shape distribution, not a one-shot at flip time -- register every
+real run via `bth run`, not just the first one.
+
+Usage:
+    # L1 (local dry-run): verify imports/paths, no compute
+    uv run python scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.py --dry-run
+
+    # L2 (local smoke test, <60s, CPU is fine): one small case, few reps
+    uv run python scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.py --smoke \
+        --out /tmp/smoke.json
+
+    # L3 / full run (needs GPU): submit via myxcel preempt-gpu preset
+    uv run python scripts/benchmarks/bench_xtrax_vs_aminx_dispatch_gpu.py \
+        --n-warmup 10 --n-timed 50 \
+        --out outputs/results/xtrax_vs_aminx_dispatch_gpu.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+logging.getLogger("jax").setLevel(logging.ERROR)
+logging.getLogger("absl").setLevel(logging.ERROR)
+
+logger = logging.getLogger(__name__)
+
+SEQ_LEN = 208  # TEV protease, 1LVB.cif chain A -- the real structure this
+# project's W1a.1 confirmatory campaign already used and validated.
+
+# num_states values spanning Vmap and SafeMap regimes at production scale.
+# The necklace campaign's (states x models x replicates x candidates) grid
+# does not yet fix concrete R/C values (prereg leaves them symbolic) -- this
+# sweeps a representative range rather than one pinned number.
+NUM_STATES_CASES: list[int] = [1, 8, 32, 128]
+
+SMOKE_NUM_STATES_CASES: list[int] = [4]
+
+
+def _build_fixture(num_states: int, seq_len: int, seed: int = 42):
+    """Synthetic geometry at a production-representative size.
+
+    Not real TEV protease geometry (random coordinates) -- this benchmark
+    measures dispatch/tiling overhead, not model biological correctness, so
+    a real CIF fixture isn't needed. seq_len=208 alone is what makes this
+    "production-representative", matching this project's actual TEV
+    protease structure size (1LVB.cif chain A).
+    """
+    from aminx.inference.bundle_builder import build_inference_bundle
+    from aminx.model import Aminx
+
+    rng = np.random.default_rng(seed)
+    jax_key = jax.random.PRNGKey(seed)
+
+    model = Aminx(
+        node_features=64,
+        edge_features=64,
+        hidden_features=64,
+        num_encoder_layers=2,
+        num_decoder_layers=2,
+        k_neighbors=5,
+        dropout_rate=0.0,
+        key=jax_key,
+    )
+    model = eqx.tree_inference(model, value=True)
+
+    coordinates = jnp.array(rng.normal(size=(seq_len, 4, 3)).astype(np.float32))
+    mask = jnp.ones((seq_len,), dtype=jnp.float32)
+    residue_index = jnp.arange(seq_len, dtype=jnp.int32)
+    chain_index = jnp.zeros((seq_len,), dtype=jnp.int32)
+
+    coordinates_stack = jnp.stack([coordinates] * num_states, axis=0)
+    mask_stack = jnp.stack([mask] * num_states, axis=0)
+    residue_index_stack = jnp.stack([residue_index] * num_states, axis=0)
+    chain_index_stack = jnp.stack([chain_index] * num_states, axis=0)
+
+    sequence_tokens = jnp.array(rng.integers(0, 20, size=(seq_len,), dtype=np.int32))
+    sequence_oh = jax.nn.one_hot(sequence_tokens, 21)
+
+    state_weights = jnp.ones(num_states) / num_states
+    bundle, config = build_inference_bundle(
+        coords=coordinates_stack,
+        mask=mask_stack,
+        residue_index=residue_index_stack,
+        chain_index=chain_index_stack,
+        sequence=sequence_oh,
+        state_weights=state_weights,
+        mode="score_conditional",
+    )
+    return model, bundle, config
+
+
+def run_case(num_states: int, seq_len: int, n_warmup: int, n_timed: int) -> dict:
+    import time
+
+    from aminx.inference.decode.conditional import ConditionalDecode
+    from aminx.inference.encode import make_encode_fn
+    from aminx.inference.logits import make_stage_set
+    from aminx.tiling.dispatch import make_axis_dispatch, make_axis_dispatch_via_xtrax
+    from aminx.tiling.planner import AxisSpec, BatchPlanner
+
+    model, bundle, config = _build_fixture(num_states, seq_len)
+
+    k_enc, k_dec = jax.random.split(jax.random.PRNGKey(0))
+    encode_fn = make_encode_fn(model, use_rolling_state=False)
+    enc = encode_fn(bundle, k_enc, config)
+    stage_set = make_stage_set(
+        strategy="arithmetic_mean", state_weights=bundle.conditioning.state_weights,
+    )
+
+    # Let the real planner choose Vmap vs SafeMap for this num_states, same
+    # as production would -- not hand-picking the strategy.
+    default_batch_size = 32
+    spec = AxisSpec(
+        name="state",
+        axis_index=0,
+        cardinality=num_states,
+        default_batch_size=default_batch_size,
+        tile_granularity=default_batch_size,
+        heterogeneous=True,  # state is aminx's canonical heterogeneous axis
+        doc="production-shape GPU throughput bench axis",
+    )
+    elements_per_row = seq_len * 4 * 3  # coords shape per state, rough proxy
+    estimate_memory = lambda decisions: (  # noqa: E731
+        decisions[0].spec.cardinality
+        if decisions[0].batch_size == 0
+        else decisions[0].batch_size
+    ) * elements_per_row
+    planner = BatchPlanner(
+        axes=[spec], budget_bytes=default_batch_size * elements_per_row,
+        estimate_memory=estimate_memory,
+    )
+    decision = planner.plan().decisions[0]
+    strategy_name = type(decision.strategy).__name__
+
+    def _make_counter():
+        counter = {"n": 0}
+
+        def cond_decode_with_counter(iterator):
+            counter["n"] += 1
+            return ConditionalDecode(model=model, state_iterator=iterator)
+
+        return counter, cond_decode_with_counter
+
+    def _time_path(dispatch_fn):
+        iterator = dispatch_fn(decision.strategy, axis="state")
+        counter, make_decode = _make_counter()
+
+        @eqx.filter_jit
+        def run(key):
+            counter["n"] += 1
+            decode = ConditionalDecode(model=model, state_iterator=iterator)
+            return decode(key=key, enc=enc, bundle=bundle, config=config, stage_set=stage_set)
+
+        for _ in range(n_warmup):
+            out = run(k_dec)
+            jax.block_until_ready(out)
+
+        times: list[float] = []
+        for _ in range(n_timed):
+            start = time.perf_counter()
+            out = run(k_dec)
+            jax.block_until_ready(out)
+            times.append(time.perf_counter() - start)
+
+        # Recompiles = trace count minus warmup+timed calls that hit cache;
+        # counter increments once per Python-level trace under filter_jit.
+        return times, counter["n"]
+
+    legacy_times, legacy_recompiles = _time_path(make_axis_dispatch)
+    adapter_times, adapter_recompiles = _time_path(make_axis_dispatch_via_xtrax)
+
+    legacy_mean = float(np.mean(legacy_times))
+    legacy_stderr = float(np.std(legacy_times, ddof=1) / np.sqrt(len(legacy_times)))
+    adapter_mean = float(np.mean(adapter_times))
+    adapter_stderr = float(np.std(adapter_times, ddof=1) / np.sqrt(len(adapter_times)))
+    throughput_ratio = adapter_mean / legacy_mean if legacy_mean > 0 else float("nan")
+
+    return {
+        "num_states": num_states,
+        "seq_len": seq_len,
+        "strategy": strategy_name,
+        "legacy_recompiles": legacy_recompiles,
+        "adapter_recompiles": adapter_recompiles,
+        "recompile_parity": legacy_recompiles == adapter_recompiles,
+        "legacy_mean_s": legacy_mean,
+        "legacy_stderr_s": legacy_stderr,
+        "adapter_mean_s": adapter_mean,
+        "adapter_stderr_s": adapter_stderr,
+        "adapter_vs_legacy_throughput_ratio": throughput_ratio,
+        "n_warmup": n_warmup,
+        "n_timed": n_timed,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n-warmup", type=int, default=10)
+    parser.add_argument("--n-timed", type=int, default=50)
+    parser.add_argument("--seq-len", type=int, default=SEQ_LEN)
+    parser.add_argument("--out", type=Path, default=None)
+    parser.add_argument("--dry-run", action="store_true", help="L1 gate: verify imports only")
+    parser.add_argument(
+        "--smoke", action="store_true", help="L2 gate: one small case, few reps, <60s",
+    )
+    parser.add_argument(
+        "--replay",
+        type=Path,
+        default=None,
+        help="Re-emit an already-computed result JSON (e.g. computed on cluster, "
+        "pulled locally) for bathos tracking, without recomputing.",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        logger.addHandler(handler)
+
+    if args.replay is not None:
+        result = json.loads(args.replay.read_text())
+        print(json.dumps(result, indent=2))
+        if args.out is not None and args.out != args.replay:
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(json.dumps(result, indent=2))
+        sys.exit(0)
+
+    if args.dry_run:
+        from aminx.inference.decode.conditional import ConditionalDecode  # noqa: F401
+        from aminx.tiling.dispatch import make_axis_dispatch, make_axis_dispatch_via_xtrax  # noqa: F401
+
+        print(json.dumps({"dry_run": "ok", "device": str(jax.devices())}))
+        sys.exit(0)
+
+    if args.smoke:
+        cases_spec = SMOKE_NUM_STATES_CASES
+        n_warmup, n_timed = 2, 3
+    else:
+        cases_spec = NUM_STATES_CASES
+        n_warmup, n_timed = args.n_warmup, args.n_timed
+
+    logger.info(f"Device: {jax.devices()}")
+
+    cases = []
+    for num_states in cases_spec:
+        logger.info(f"Running num_states={num_states} seq_len={args.seq_len}")
+        cases.append(run_case(num_states, args.seq_len, n_warmup, n_timed))
+
+    all_recompile_parity = all(c["recompile_parity"] for c in cases)
+    max_throughput_ratio = max(c["adapter_vs_legacy_throughput_ratio"] for c in cases)
+
+    result = {
+        "cases": cases,
+        "all_recompile_parity": all_recompile_parity,
+        "max_adapter_vs_legacy_throughput_ratio": max_throughput_ratio,
+        "device": str(jax.devices()),
+    }
+
+    print(json.dumps(result, indent=2))
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(result, indent=2))
+        logger.info(f"Wrote result JSON to {args.out}")
+
+    sys.exit(0 if all_recompile_parity else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Completes T2.GATE (#1556) for EPIC #1541. The standing cluster GPU throughput gate the spec's premortem calls for, run on production-representative shapes (L=208, TEV protease 1LVB.cif chain A scale) via myxcel's `preempt-gpu` preset.

**Result: PASS.** Legacy `make_axis_dispatch` vs T2.4's `make_axis_dispatch_via_xtrax`, num_states swept [1, 8, 32, 128]:
- Recompile parity: 100% (all 4 cases)
- Throughput ratio: 0.983x–1.002x (max 1.0018x) -- comfortably under the 1.10x PASS threshold
- Far more statistically stable than the earlier CPU-synthetic bench (~0.5-1% stderr here vs. that bench's 1.03x-1.79x spread across identical repeats -- confirms production-scale GPU timing is much less noisy than microsecond CPU dispatch overhead)

Followed CLUSTER.md's L1 (dry-run) -> L2 (local CPU smoke, <60s) -> L3 (cluster smoke, reduced budget) gate discipline before the full submission. Along the way found and fixed two real infra gaps:
- The cluster's aminx checkout was stale by this session's entire commit history -- `myxcel push` turned out to be additive-only (never overwrites existing remote files even when content differs). Worked around via direct `rsync --checksum`; filed as aminx backlog #3121 for the myxcel-side fix/documentation.
- The GPU preset initially ran silently on CPU -- `uv run` needs `--extra cuda12` explicitly requested, same class of gotcha as this session's earlier xtrax dependency-resolution fix.

Adds a `--replay` flag to the script (mirroring the pattern already used elsewhere this session) so the cluster-computed result could be tracked via local `bth run` without recomputing.

**With this, T2.4/T2.6/T2.GATE are all satisfied for EPIC #1541.** Only P3 (the actual call-site migration flip, ~31 call sites, already cheap per RS-track velocity calibration) remains.

## Test plan
- [x] L1 dry-run passed (local + cluster login node)
- [x] L2 local CPU smoke passed (<60s)
- [x] L3 cluster GPU smoke passed (confirmed real `CudaDevice`, not silent CPU fallback)
- [x] Full production run: PASS (100% recompile parity, max throughput ratio 1.0018x)
- [x] Result tracked via `bth run --replay` in the local bathos catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyj9MgkHjdgL7ktrTTpH8w