### PR TITLE
EPIC #1541 P3 flip #1: factory.py to make_axis_dispatch_via_xtrax

### DIFF
--- a/src/aminx/inference/decode/factory.py
+++ b/src/aminx/inference/decode/factory.py
@@ -2,10 +2,11 @@
 
 Implements make_decode_fn: converts (mode, strategy) pairs into concrete mode-class
 instances (ConditionalDecode, UnconditionalDecode, AutoregressiveDecode, STEDecode),
-dispatching each mode's state-axis strategy via tiling/dispatch.make_axis_dispatch.
+dispatching each mode's state-axis strategy via tiling/dispatch.make_axis_dispatch_via_xtrax
+(EPIC #1541 T2.GATE-passed flip, 2026-07-06).
 
-Risk D-12 mitigation: wraps DispatchRejected from make_axis_dispatch with mode-name
-context to help users understand which mode failed the dispatch check.
+Risk D-12 mitigation: wraps DispatchRejected from make_axis_dispatch_via_xtrax with
+mode-name context to help users understand which mode failed the dispatch check.
 
 Note: Stage-set projection for STE is handled internally by STEDecode (see ste.py).
 """
@@ -28,7 +29,7 @@ from aminx.inference.decode.mode import (
 from aminx.inference.decode.ste import STEDecode
 from aminx.inference.decode.unconditional import UnconditionalDecode
 from aminx.tiling.carry_shape import CarryShape
-from aminx.tiling.dispatch import DispatchRejected, make_axis_dispatch
+from aminx.tiling.dispatch import DispatchRejected, make_axis_dispatch_via_xtrax
 from aminx.tiling.iterator import JaxScanIterator
 from aminx.tiling.strategy import AxisStrategy
 from aminx.utils.decoding_order import DecodingOrderFn, random_decoding_order
@@ -45,7 +46,7 @@ def make_decode_fn(
   """Factory: resolve a decode mode and strategy into a typed mode-class instance.
 
   Dispatches by mode type, resolving the state-axis strategy via
-  tiling/dispatch.make_axis_dispatch. Wraps DispatchRejected with mode-name
+  tiling/dispatch.make_axis_dispatch_via_xtrax. Wraps DispatchRejected with mode-name
   context (Risk D-12) to help users understand which mode caused rejection.
 
   Parameters
@@ -88,15 +89,15 @@ def make_decode_fn(
 
   try:
     if isinstance(mode, ConditionalMode):
-      state_iter = make_axis_dispatch(strategy, axis="state")
+      state_iter = make_axis_dispatch_via_xtrax(strategy, axis="state")
       return ConditionalDecode(model=model, state_iterator=state_iter)
 
     if isinstance(mode, UnconditionalMode):
-      state_iter = make_axis_dispatch(strategy, axis="state")
+      state_iter = make_axis_dispatch_via_xtrax(strategy, axis="state")
       return UnconditionalDecode(model=model, state_iterator=state_iter)
 
     if isinstance(mode, AutoregressiveMode):
-      state_iter = make_axis_dispatch(strategy, axis="state")
+      state_iter = make_axis_dispatch_via_xtrax(strategy, axis="state")
       wave_iter = JaxScanIterator()
       # Default wave_carry shape (L=1024); actual shape materialized in __call__
       wave_carry = CarryShape(name="sequence", shape=(1024,), dtype=jnp.int32)

--- a/tests/inference/decode/test_factory.py
+++ b/tests/inference/decode/test_factory.py
@@ -27,7 +27,7 @@ from aminx.inference.decode.mode import (
 from aminx.inference.decode.ste import STEDecode
 from aminx.inference.decode.unconditional import UnconditionalDecode
 from aminx.tiling.dispatch import DispatchRejected
-from aminx.tiling.iterator import JaxScanIterator, SafeMapIterator, VmapIterator
+from aminx.tiling.iterator import JaxScanIterator
 from aminx.tiling.strategy import SafeMap, Scan, Vmap
 
 
@@ -48,7 +48,7 @@ class TestMakeDecodeFnConditional:
         result = make_decode_fn(model, mode, strategy)
 
         assert isinstance(result, ConditionalDecode)
-        assert isinstance(result.state_iterator, VmapIterator)
+        assert type(result.state_iterator).__name__ == "VmapIterator"
         assert result.model is model
 
     def test_conditional_with_safemap(self):
@@ -60,7 +60,7 @@ class TestMakeDecodeFnConditional:
         result = make_decode_fn(model, mode, strategy)
 
         assert isinstance(result, ConditionalDecode)
-        assert isinstance(result.state_iterator, SafeMapIterator)
+        assert type(result.state_iterator).__name__ == "SafeMapIterator"
         assert result.state_iterator.tile == 4
         assert result.model is model
 
@@ -77,7 +77,7 @@ class TestMakeDecodeFnUnconditional:
         result = make_decode_fn(model, mode, strategy)
 
         assert isinstance(result, UnconditionalDecode)
-        assert isinstance(result.state_iterator, VmapIterator)
+        assert type(result.state_iterator).__name__ == "VmapIterator"
         assert result.model is model
 
     def test_unconditional_with_safemap(self):
@@ -89,7 +89,7 @@ class TestMakeDecodeFnUnconditional:
         result = make_decode_fn(model, mode, strategy)
 
         assert isinstance(result, UnconditionalDecode)
-        assert isinstance(result.state_iterator, SafeMapIterator)
+        assert type(result.state_iterator).__name__ == "SafeMapIterator"
         assert result.state_iterator.tile == 2
 
 
@@ -107,7 +107,7 @@ class TestMakeDecodeFnAutoregressive:
         from aminx.inference.decode.autoregressive import AutoregressiveDecode
 
         assert isinstance(result, AutoregressiveDecode)
-        assert isinstance(result.state_iterator, VmapIterator)
+        assert type(result.state_iterator).__name__ == "VmapIterator"
         assert isinstance(result.wave_iterator, JaxScanIterator)
         # Check wave_carry metadata
         assert result.wave_carry.name == "sequence"
@@ -126,7 +126,7 @@ class TestMakeDecodeFnAutoregressive:
         from aminx.inference.decode.autoregressive import AutoregressiveDecode
 
         assert isinstance(result, AutoregressiveDecode)
-        assert isinstance(result.state_iterator, SafeMapIterator)
+        assert type(result.state_iterator).__name__ == "SafeMapIterator"
         assert result.state_iterator.tile == 4
         assert isinstance(result.wave_iterator, JaxScanIterator)
 
@@ -145,7 +145,7 @@ class TestMakeDecodeFnSTE:
         assert isinstance(result, STEDecode)
         assert result.iterations == 50
         assert isinstance(result.inner, ConditionalDecode)
-        assert isinstance(result.inner.state_iterator, VmapIterator)
+        assert type(result.inner.state_iterator).__name__ == "VmapIterator"
 
     def test_ste_with_conditional_inner_safemap(self):
         """STEMode with SafeMap inner strategy."""
@@ -158,7 +158,7 @@ class TestMakeDecodeFnSTE:
         assert isinstance(result, STEDecode)
         assert result.iterations == 100
         assert isinstance(result.inner, ConditionalDecode)
-        assert isinstance(result.inner.state_iterator, SafeMapIterator)
+        assert type(result.inner.state_iterator).__name__ == "SafeMapIterator"
         assert result.inner.state_iterator.tile == 3
 
     def test_ste_default_iterations(self):


### PR DESCRIPTION
## Summary
First real P3 call-site flip for EPIC #1541 -- the one call site T2.GATE's evidence directly covers.

- `src/aminx/inference/decode/factory.py`: all 3 `make_axis_dispatch` calls (Conditional/Unconditional/AutoregressiveMode) now route through T2.4's `make_axis_dispatch_via_xtrax`.
- Found and fixed a real migration cost: `tests/inference/decode/test_factory.py` asserted nominal `isinstance(state_iterator, aminx.tiling.iterator.{Vmap,SafeMap}Iterator)`. The adapter now returns xtrax's classes (structurally identical, satisfies aminx's `MapIterator` Protocol, but a different concrete type) -- 8 assertions failed. Fixed by checking `type(x).__name__` instead, preserving the original test intent while being correct regardless of which library's class satisfies the shape.

**This is the exact class of breakage to expect at every remaining call site whose tests do nominal isinstance checks against `aminx.tiling` classes** -- worth flagging for whoever picks up the rest of P3.

Remaining ~29 call sites are NOT simple repeats of this flip -- they touch structurally different pieces of `aminx.tiling` (`BatchPlanner`/`AxisSpec` in `host/plan.py`, direct iterator construction in 5 files, `CarrySpec`/`DedupSpec` in `run/specs.py`, bucketing), none of which T2.GATE's dispatch-specific adapter covers. Each needs its own T2.4-style adapter + parity gate.

## Test plan
- [x] `tests/inference/decode/test_factory.py`: 13/13 pass after the isinstance-check fix
- [x] Full test suite: 1427 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyj9MgkHjdgL7ktrTTpH8w