### PR TITLE
EPIC #1541 P3: migrate iterator construction to xtrax.tiling; planner stays local

### DIFF
--- a/.praxia/docs/INDEX.md
+++ b/.praxia/docs/INDEX.md
@@ -44,6 +44,7 @@
 - [260612_proteinfeatures-shared-vs-local](decisions/260612_proteinfeatures-shared-vs-local.md) — **Accepted 2026-06-12**: Confirms Option A complete — aminx.potts imports from aminx.model.features; no vendor copy in potts tree. Supersedes adr/260605.
 - [260630_runtimebundle-inputresolver-compose-not-subclass](decisions/260630_runtimebundle-inputresolver-compose-not-subclass.md) — **Accepted 2026-06-30**: aminx's planned RuntimeBundle (#1910) must compose, not subclass, xtrax.run.resolver.RuntimeBundle (frozen-vs-non-frozen dataclass conflict); InputResolver implemented via functools.singledispatch per xtrax's own prescribed pattern. Zero upstream xtrax changes needed.
 - [260702_wave-color-commits-retroactive-attribution](decisions/260702_wave-color-commits-retroactive-attribution.md) — **Accepted 2026-07-02**: retroactively attributes 5 wave-color commits (54d6d84, 0be59ef, 4060e9d, 0670197, 1cec556) to mpnn_ext Epic WAVE (#2871); kept in place, no revert. Backlog #2954 tracks the enforcement lint that should have caught this.
+- [260706_planner-stays-on-aminx-tiling-by-design](decisions/260706_planner-stays-on-aminx-tiling-by-design.md) — **Accepted 2026-07-06**: EPIC #1541 P3 — `BatchPlanner`/`AxisSpec` stays on `aminx.tiling.planner`, not migrated to xtrax; joint multi-axis budget-demotion loop has no xtrax equivalent (algorithmic gap, not structural). Dispatch-layer flip (T2.4) unaffected.
 
 ## ADRs (Legacy)
 

--- a/.praxia/docs/decisions/260706_planner-stays-on-aminx-tiling-by-design.md
+++ b/.praxia/docs/decisions/260706_planner-stays-on-aminx-tiling-by-design.md
@@ -1,0 +1,70 @@
+---
+title: BatchPlanner/AxisSpec stays on aminx.tiling.planner — not migrated to xtrax.tiling.plan
+status: Accepted
+date: 2026-07-06
+related_epic: "#1541 (aminx→xtrax tiling refactor), gate #1556 (T2.GATE)"
+---
+
+# Decision
+
+`aminx.tiling.planner.BatchPlanner` / `AxisSpec` (`src/aminx/tiling/planner.py`) will **not** be
+migrated to `xtrax.tiling.plan.BatchPlanner` / `AxisSpec` as part of EPIC #1541's P3 call-site
+migration. The planner stays local, indefinitely, by design — not deferred, not blocked.
+
+This applies only to the planning *algorithm* (`BatchPlanner.plan()`). The dispatch-layer flip
+(T2.4's `make_axis_dispatch_via_xtrax`, already landed in `factory.py`) is unaffected and unrelated;
+this decision does not reopen or roll back that work.
+
+## Why
+
+Scoping this migration piece (recon, 2026-07-06) surfaced a real algorithmic gap, not a structural
+one:
+
+- **xtrax's `BatchPlanner._decide_strategy`** decides each axis *independently*: cardinality vs.
+  `default_batch_size`, with an optional per-axis `memory_estimator(spec) -> bytes` checked against
+  the *hardware's* `jax.devices()[0].memory_stats()['bytes_limit']`.
+- **aminx's `BatchPlanner.plan()`** runs a *joint, multi-axis greedy demotion loop* (Phase 2) against
+  a *caller-supplied* `budget_bytes` (`headroom × device_limit − param_bytes`), demoting axes from
+  Vmap→SafeMap one at a time in `axis_index` order until the **combined product** across all axes'
+  decisions fits. `estimate_memory_theoretical` takes the whole decision list, not one axis.
+
+These are different algorithms. They agree when every axis independently fits its budget, and
+diverge under real multi-axis memory pressure — exactly the case the planner exists to handle. No
+adapter can translate one into the other; only reimplementing aminx's loop on top of xtrax's
+per-axis primitive, or upstreaming the joint-budget algorithm into xtrax itself, would preserve
+behavior. Neither is a translate-and-wrap job like T2.4 was.
+
+Two secondary findings reinforce this:
+
+1. `plan_bucketed()` (`host/plan.py:780`) does `dataclasses.replace(planner, axes=modified_axes)` —
+   relies on aminx's `BatchPlanner` being a frozen dataclass with `axes` as a field. xtrax's
+   `BatchPlanner` is a plain class; axes are passed to `.plan(specs)`, not held as a field.
+   `dataclasses.replace` on it is a hard `TypeError`.
+2. `host/kernel_dispatch.py`'s `_dispatch_axis` is a **second, independent** consumer of
+   `AxisDecision.strategy` — it hand-rolls its own `isinstance(strategy, Vmap/SafeMap/Scan/DedupGather)`
+   handling against `aminx.tiling.strategy` classes directly (via `aminx.utils.safe_scan`), and never
+   goes through `tiling/dispatch.py` / T2.4's adapter at all. Migrating the planner alone wouldn't
+   flip anything real here without also touching this second dispatcher.
+
+This follows the same precedent already set in `_validate_plan_topology` (`host/plan.py:257`): generic,
+reusable checks (Rules 1-2) delegate to `xtrax.stages.validate_plan_topology`; the domain-specific
+check (Rule 3, STEDecode/UnconditionalDecodeStep) stays local. The joint-budget demotion loop is
+aminx's own memory-budgeting concern — genuinely useful, but not a generic tiling primitive xtrax's
+architecture provides today.
+
+## What this closes out
+
+- The "planner" line item in EPIC #1541 / P3's remaining-pieces list is resolved as **won't-migrate**,
+  not pending.
+- `AxisSpec`'s cosmetic field drift (aminx has `axis_index`/`doc`; xtrax has `bucket_boundaries`/`role`)
+  is not worth chasing on its own — xtrax's `bucket_boundaries` would be a free win (aminx's planner
+  has a literal `# TODO: introduce bucketing management`, never built) but isn't reason enough to
+  migrate the whole planner.
+- Remaining P3 pieces (per the EPIC #1541 handoff): the 5 direct `aminx.tiling.iterator` construction
+  sites, then `carry`/`carry_shape`/`dedup`, then `bucketing`/`pad`.
+
+## Reopening this decision
+
+If xtrax later grows an equivalent joint-budget, caller-supplied-budget demotion algorithm (upstream
+feature, not scoped here), revisit. Until then, `aminx.tiling.planner` is the intended long-term home
+for this logic, not a shim awaiting migration.

--- a/src/aminx/inference/decode/autoregressive.py
+++ b/src/aminx/inference/decode/autoregressive.py
@@ -9,8 +9,8 @@ After the wave scan completes, a post-hoc scatter scan maps per-wave logits back
 to per-position logits (Risk D-11 mitigation) — this stays outside the iterator.
 
 Key invariants:
-- The wave_iterator field is always JaxScanIterator (structural invariant; no
-  user-facing W-axis strategy knob per Risk D-3).
+- The wave_iterator field is always xtrax.tiling.JaxScanIterator (structural
+  invariant; no user-facing W-axis strategy knob per Risk D-3).
 - The state_iterator is injected at factory time, controlling S-axis parallelism.
 - CarryShape is metadata-only; the actual init-array is materialized inside
   __call__ from the metadata.
@@ -26,6 +26,7 @@ import jax
 import jax.lax
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
+from xtrax.tiling import MapIterator, ScanIterator
 
 from aminx.inference.decode._kernel import (
   _decode_one_step,
@@ -33,7 +34,6 @@ from aminx.inference.decode._kernel import (
 )
 from aminx.inference.sample_autoregressive import SampleResult
 from aminx.tiling.carry_shape import CarryShape
-from aminx.tiling.iterator import MapIterator, ScanIterator
 from aminx.types.bundles import EncoderOutput, InferenceBundle, WaveScheduleBundle
 from aminx.types.configs import InferenceConfig
 from aminx.types.stages import StageSet

--- a/src/aminx/inference/decode/conditional.py
+++ b/src/aminx/inference/decode/conditional.py
@@ -16,13 +16,13 @@ from typing import Any
 
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
+from xtrax.tiling import MapIterator
 
 from aminx.inference.decode._base import _ConditionalDecodeBase
 from aminx.inference.decode._kernel import (
   _decode_one_step,
   _project_logits,
 )
-from aminx.tiling.iterator import MapIterator
 from aminx.types.arrays import Logits
 from aminx.types.bundles import EncoderOutput, InferenceBundle
 from aminx.types.configs import InferenceConfig

--- a/src/aminx/inference/decode/factory.py
+++ b/src/aminx/inference/decode/factory.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import jax.numpy as jnp
+from xtrax.tiling import JaxScanIterator
 
 from aminx.inference.decode._base import _ConditionalDecodeBase
 from aminx.inference.decode.conditional import ConditionalDecode
@@ -30,7 +31,6 @@ from aminx.inference.decode.ste import STEDecode
 from aminx.inference.decode.unconditional import UnconditionalDecode
 from aminx.tiling.carry_shape import CarryShape
 from aminx.tiling.dispatch import DispatchRejected, make_axis_dispatch_via_xtrax
-from aminx.tiling.iterator import JaxScanIterator
 from aminx.tiling.strategy import AxisStrategy
 from aminx.utils.decoding_order import DecodingOrderFn, random_decoding_order
 
@@ -74,7 +74,7 @@ def make_decode_fn(
 
   Notes
   -----
-  For AutoregressiveMode, the wave-axis iterator is always JaxScanIterator
+  For AutoregressiveMode, the wave-axis iterator is always xtrax.tiling.JaxScanIterator
   (a structural invariant); only the state-axis strategy is user-configurable.
   The wave_carry is initialized with a default shape of (1024,) (typical L);
   the actual shape is materialized inside AutoregressiveDecode.__call__ from

--- a/src/aminx/inference/decode/unconditional.py
+++ b/src/aminx/inference/decode/unconditional.py
@@ -14,9 +14,9 @@ from typing import Any
 import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
+from xtrax.tiling import MapIterator
 
 from aminx.inference.decode._kernel import _project_logits
-from aminx.tiling.iterator import MapIterator
 from aminx.types.bundles import EncoderOutput, InferenceBundle
 from aminx.types.stages import StageSet
 

--- a/src/aminx/inference/score_conditional.py
+++ b/src/aminx/inference/score_conditional.py
@@ -6,10 +6,10 @@ from typing import Any, cast
 import jax
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
+from xtrax.tiling import VmapIterator
 
 from aminx.inference.decode.conditional import ConditionalDecode  # noqa: TID251
 from aminx.inference.encode import make_encode_fn
-from aminx.tiling.iterator import VmapIterator
 from aminx.types.arrays import Logits
 from aminx.types.bundles import EncoderOutput as BundleEncoderOutput
 from aminx.types.bundles import InferenceBundle

--- a/tests/inference/decode/test_factory.py
+++ b/tests/inference/decode/test_factory.py
@@ -27,7 +27,6 @@ from aminx.inference.decode.mode import (
 from aminx.inference.decode.ste import STEDecode
 from aminx.inference.decode.unconditional import UnconditionalDecode
 from aminx.tiling.dispatch import DispatchRejected
-from aminx.tiling.iterator import JaxScanIterator
 from aminx.tiling.strategy import SafeMap, Scan, Vmap
 
 
@@ -108,7 +107,7 @@ class TestMakeDecodeFnAutoregressive:
 
         assert isinstance(result, AutoregressiveDecode)
         assert type(result.state_iterator).__name__ == "VmapIterator"
-        assert isinstance(result.wave_iterator, JaxScanIterator)
+        assert type(result.wave_iterator).__name__ == "JaxScanIterator"
         # Check wave_carry metadata
         assert result.wave_carry.name == "sequence"
         assert result.wave_carry.shape == (1024,)  # Default L for test
@@ -128,7 +127,7 @@ class TestMakeDecodeFnAutoregressive:
         assert isinstance(result, AutoregressiveDecode)
         assert type(result.state_iterator).__name__ == "SafeMapIterator"
         assert result.state_iterator.tile == 4
-        assert isinstance(result.wave_iterator, JaxScanIterator)
+        assert type(result.wave_iterator).__name__ == "JaxScanIterator"
 
 
 class TestMakeDecodeFnSTE:


### PR DESCRIPTION
## Summary
- Migrates the 5 direct `aminx.tiling.iterator` import/construction sites to `xtrax.tiling` (factory.py's wave_iterator, score_conditional.py's hardcoded Vmap, and the `MapIterator`/`ScanIterator` Protocol annotations in conditional.py/unconditional.py/autoregressive.py). `xtrax.tiling.iterator` is a behavioral duplicate of aminx's — this is a clean drop-in swap, not an adapter.
- Fixes `test_factory.py`'s now-stale `isinstance(..., JaxScanIterator)` check with the established `type(x).__name__` pattern (concrete-class isinstance breaks across the aminx/xtrax boundary; same fix already applied to the state_iterator checks in the prior PR).
- Records `aminx.tiling.planner` (`BatchPlanner`/`AxisSpec`) stays local **by design** — scoping it surfaced a real algorithmic gap (aminx's joint multi-axis budget-demotion loop against a caller-supplied `budget_bytes` has no xtrax equivalent; xtrax decides each axis independently against hardware memory limits), not a structural gap an adapter could bridge. See `.praxia/docs/decisions/260706_planner-stays-on-aminx-tiling-by-design.md`.

## Test plan
- [x] `tests/tiling/`, `tests/inference/decode/`, `tests/inference/test_model_not_static.py`, `tests/scoring/` — 211 passed
- [x] `tests/parity/`, `tests/inference/`, `tests/sampling/test_conditional_logits.py`, `tests/model/test_mpnn.py`, `tests/model/test_ligandmpnn_equivalence.py` — 258 passed, 8 skipped (torch/cudnn unavailable, pre-existing env gap), 1 xpassed
- [x] `ty check` on all 5 changed source files — identical 8 diagnostics to HEAD (all pre-existing, none introduced)
- [x] `ruff check` — no new violations (TID251 hits confirmed pre-existing against HEAD copies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)