### PR TITLE
fix(host): recompute stale-schema done markers instead of erroring

### DIFF
--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -503,6 +503,25 @@ def _read_done_marker(path: Path) -> dict[str, Any] | None:
   return payload
 
 
+class StaleDoneMarkerSchemaError(ValueError):
+  """A done marker predates DONE_MARKER_SCHEMA_VERSION (e.g. pre-Zarr-migration HDF5).
+
+  Distinct from the other _validate_done_marker failures (hash/digest mismatch),
+  which indicate real corruption and must stay hard errors: a schema-version
+  mismatch means the row is safe to invalidate and recompute under the current
+  storage format.
+  """
+
+
+def _invalidate_stale_output(*, marker_path: Path, output_h5_path: Path) -> None:
+  """Discard a done marker and its output artifact written under a superseded schema."""
+  if output_h5_path.is_dir():
+    shutil.rmtree(output_h5_path)
+  elif output_h5_path.exists():
+    output_h5_path.unlink()
+  marker_path.unlink(missing_ok=True)
+
+
 def _validate_done_marker(
   *,
   marker: dict[str, Any],
@@ -515,7 +534,7 @@ def _validate_done_marker(
       f"Done marker schema mismatch at {marker_path}: "
       f"expected {DONE_MARKER_SCHEMA_VERSION!r}, got {marker.get('schema_version')!r}."
     )
-    raise ValueError(msg)
+    raise StaleDoneMarkerSchemaError(msg)
   if marker.get("manifest_row_hash") != manifest_row_hash:
     msg = (
       f"Done marker manifest hash mismatch at {marker_path}: "
@@ -755,21 +774,26 @@ def run_manifest_row(  # noqa: PLR0915
   manifest_hash = str(row["manifest_row_hash"])
 
   existing_marker = _read_done_marker(done_marker_path)
+  marker_is_stale = False
   if existing_marker is not None:
-    _validate_done_marker(
-      marker=existing_marker,
-      marker_path=done_marker_path,
-      output_h5_path=output_h5_path,
-      manifest_row_hash=manifest_hash,
-    )
-    return {
-      "status": "already_done",
-      "output_h5_path": str(output_h5_path),
-      "manifest_row_hash": manifest_hash,
-      "done_marker_path": str(done_marker_path),
-      "attempt_id": existing_marker.get("attempt_id"),
-    }
-  if output_h5_path.exists():
+    try:
+      _validate_done_marker(
+        marker=existing_marker,
+        marker_path=done_marker_path,
+        output_h5_path=output_h5_path,
+        manifest_row_hash=manifest_hash,
+      )
+    except StaleDoneMarkerSchemaError:
+      marker_is_stale = True
+    else:
+      return {
+        "status": "already_done",
+        "output_h5_path": str(output_h5_path),
+        "manifest_row_hash": manifest_hash,
+        "done_marker_path": str(done_marker_path),
+        "attempt_id": existing_marker.get("attempt_id"),
+      }
+  if not marker_is_stale and output_h5_path.exists():
     msg = (
       f"Output file already exists without done marker for manifest row {manifest_hash}: "
       f"{output_h5_path}"
@@ -791,19 +815,28 @@ def run_manifest_row(  # noqa: PLR0915
   ) as heartbeat_errors:
     existing_marker = _read_done_marker(done_marker_path)
     if existing_marker is not None:
-      _validate_done_marker(
-        marker=existing_marker,
-        marker_path=done_marker_path,
-        output_h5_path=output_h5_path,
-        manifest_row_hash=manifest_hash,
-      )
-      return {
-        "status": "already_done",
-        "output_h5_path": str(output_h5_path),
-        "manifest_row_hash": manifest_hash,
-        "done_marker_path": str(done_marker_path),
-        "attempt_id": existing_marker.get("attempt_id"),
-      }
+      try:
+        _validate_done_marker(
+          marker=existing_marker,
+          marker_path=done_marker_path,
+          output_h5_path=output_h5_path,
+          manifest_row_hash=manifest_hash,
+        )
+      except StaleDoneMarkerSchemaError as exc:
+        logger.warning(
+          "Discarding stale done marker for manifest row %s, recomputing: %s",
+          manifest_hash,
+          exc,
+        )
+        _invalidate_stale_output(marker_path=done_marker_path, output_h5_path=output_h5_path)
+      else:
+        return {
+          "status": "already_done",
+          "output_h5_path": str(output_h5_path),
+          "manifest_row_hash": manifest_hash,
+          "done_marker_path": str(done_marker_path),
+          "attempt_id": existing_marker.get("attempt_id"),
+        }
     if output_h5_path.exists():
       msg = (
         f"Output file already exists without done marker for manifest row {manifest_hash}: "

--- a/tests/host/test_campaign_done_marker.py
+++ b/tests/host/test_campaign_done_marker.py
@@ -12,7 +12,9 @@ from xtrax.run import zarr_content_digest
 
 from aminx.host.campaign import (
   DONE_MARKER_SCHEMA_VERSION,
+  StaleDoneMarkerSchemaError,
   _done_marker_path,
+  _invalidate_stale_output,
   _read_done_marker,
   _validate_done_marker,
   _write_done_marker,
@@ -60,7 +62,10 @@ def test_validate_rejects_schema_mismatch(tmp_path: Path) -> None:
     "manifest_row_hash": "hash123",
     "content_digest_sha256": zarr_content_digest(store_path),
   }
-  with pytest.raises(ValueError, match="schema mismatch"):
+  # Schema mismatch raises the stale-marker subclass specifically, distinct from the
+  # other three checks below (which stay plain ValueError -- real corruption, not a
+  # superseded-schema situation that's safe to invalidate and recompute).
+  with pytest.raises(StaleDoneMarkerSchemaError, match="schema mismatch"):
     _validate_done_marker(
       marker=bad_marker,
       marker_path=marker_path,
@@ -101,6 +106,41 @@ def test_validate_rejects_missing_output(tmp_path: Path) -> None:
       output_h5_path=store_path,
       manifest_row_hash="hash123",
     )
+
+
+def test_invalidate_stale_output_removes_zarr_store_and_marker(tmp_path: Path) -> None:
+  store_path = _make_store(tmp_path)
+  marker_path = _done_marker_path(store_path)
+  marker_path.write_text('{"schema_version": "some_old_h5_era_schema"}')
+
+  _invalidate_stale_output(marker_path=marker_path, output_h5_path=store_path)
+
+  assert not store_path.exists()
+  assert not marker_path.exists()
+
+
+def test_invalidate_stale_output_removes_legacy_h5_file(tmp_path: Path) -> None:
+  """Pre-Zarr-migration rows wrote a single HDF5 file at this path, not a directory."""
+  legacy_path = tmp_path / "row_output.h5"
+  legacy_path.write_bytes(b"not a real hdf5 file, just a stand-in")
+  marker_path = _done_marker_path(legacy_path)
+  marker_path.write_text('{"schema_version": "campaign_done_marker_v1"}')
+
+  _invalidate_stale_output(marker_path=marker_path, output_h5_path=legacy_path)
+
+  assert not legacy_path.exists()
+  assert not marker_path.exists()
+
+
+def test_invalidate_stale_output_tolerates_missing_artifact(tmp_path: Path) -> None:
+  """The output may already be gone (e.g. a prior partial cleanup); only the marker remains."""
+  missing_path = tmp_path / "already_gone.zarr"
+  marker_path = _done_marker_path(missing_path)
+  marker_path.write_text('{"schema_version": "campaign_done_marker_v1"}')
+
+  _invalidate_stale_output(marker_path=marker_path, output_h5_path=missing_path)
+
+  assert not marker_path.exists()
 
 
 def test_validate_detects_corrupted_content(tmp_path: Path) -> None:

--- a/tests/host/test_comp536_campaign_manifest.py
+++ b/tests/host/test_comp536_campaign_manifest.py
@@ -596,3 +596,72 @@ class TestRunManifestRowZarrLifecycle:
             )
         assert result2["status"] == "already_done"
         mock_sample.assert_not_called()
+
+    def test_stale_schema_marker_is_recomputed_not_errored(self, tmp_path: Path) -> None:
+        """A done marker from a superseded schema (e.g. pre-Zarr-migration HDF5) must be
+        discarded and the row recomputed, not surfaced as a fatal error (COMP-536 regression:
+        this previously propagated as an unhandled ValueError and failed the whole row).
+        """
+        import json as _json
+
+        import numpy as np
+        import zarr
+
+        from aminx.host.campaign import (
+            DONE_MARKER_SCHEMA_VERSION,
+            _done_marker_path,
+            run_manifest_row,
+        )
+
+        output_path = tmp_path / "row_output.zarr"
+        manifest_path = tmp_path / "manifest.json"
+        row_hash = "test_row_hash_stale_schema"
+        manifest = {
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "rows": [
+                {
+                    "manifest_row_hash": row_hash,
+                    "job_id": "job0",
+                    "job_index": 0,
+                    "sampling_spec": {
+                        "inputs": ["/tmp/test.pdb"],
+                        "output_h5_path": str(output_path),
+                    },
+                },
+            ],
+        }
+        manifest_path.write_text(json.dumps(manifest))
+
+        # Simulate a leftover pre-migration artifact: a plain HDF5-era output file (not a
+        # Zarr directory) plus a done marker written under the old schema.
+        output_path.write_bytes(b"stand-in for a pre-migration HDF5 file")
+        marker_path = _done_marker_path(output_path)
+        marker_path.write_text(
+            _json.dumps(
+                {
+                    "schema_version": "campaign_done_marker_v1",
+                    "manifest_row_hash": row_hash,
+                    "content_digest_sha256": "irrelevant-under-old-schema",
+                },
+            ),
+        )
+
+        def _fake_sample(spec):
+            root = zarr.open_group(str(spec.output_h5_path), mode="a")
+            arr = root.create_array(name="sequences", shape=(1,), dtype="int32")
+            arr[...] = np.array([7], dtype=np.int32)
+            return {"status": "completed"}
+
+        with patch("aminx.host.campaign.sample", side_effect=_fake_sample) as mock_sample:
+            result = run_manifest_row(
+                manifest_path=str(manifest_path),
+                row_hash=row_hash,
+                lock_backend="local_fs",
+            )
+
+        mock_sample.assert_called_once()
+        assert result["status"] == "completed"
+        assert output_path.is_dir()  # replaced by a real Zarr store, not the stale file
+
+        new_marker = json.loads(marker_path.read_text())
+        assert new_marker["schema_version"] == DONE_MARKER_SCHEMA_VERSION


### PR DESCRIPTION
## Summary
- `DONE_MARKER_SCHEMA_VERSION` was bumped v1→v2 in #91 for the HDF5→Zarr storage migration — correct, since old markers point at pre-migration output shapes and should be invalidated.
- But `_validate_done_marker` raised a plain `ValueError` for schema mismatch, identical to the real-corruption checks (hash/digest mismatch), and `run_manifest_row` never caught it. Every row still carrying a v1 marker permanently errors instead of being recomputed.
- Found via the necklace P2 PoE production run (job 17560535): 44/147 rows per model, across all 6 models, stuck in this state — the job reports FAILED even though the other 103/147 rows succeeded.

## Changes
- New `StaleDoneMarkerSchemaError(ValueError)` — schema-version mismatch raises this specifically; the other three `_validate_done_marker` checks (manifest-hash, missing-output, content-digest) are untouched and still raise plain `ValueError`, since those indicate real corruption, not a superseded schema.
- New `_invalidate_stale_output()` — discards the stale marker plus its output artifact, handling both a legacy plain HDF5 file (pre-migration) and a Zarr store directory (post-migration).
- `run_manifest_row` catches `StaleDoneMarkerSchemaError` at both the pre-lock and in-lock marker checks, invalidates once (under the lock, to avoid a race), and falls through to a normal recompute.

## Test plan
- [x] `tests/host/test_campaign_done_marker.py` — new coverage for `StaleDoneMarkerSchemaError` type, `_invalidate_stale_output` (Zarr dir, legacy file, already-missing artifact)
- [x] `tests/host/test_comp536_campaign_manifest.py` — new end-to-end `run_manifest_row` regression test: a stale v1 marker + legacy HDF5-shaped artifact is discarded and the row recomputed (not errored), landing a fresh v2 marker
- [x] `uv run pytest tests/host/ -q` — 274 passed, 9 pre-existing skips, no regressions
- [x] `uv run ruff check` on changed files — no new findings (pre-existing unrelated TRY004 finding confirmed present on origin/main baseline too)