### PR TITLE
fix(inference): cross-state residue alignment for PoE multistate fusion

### DIFF
--- a/src/aminx/inference/bundle_builder.py
+++ b/src/aminx/inference/bundle_builder.py
@@ -49,6 +49,7 @@ def build_inference_bundle(
   fixed_mask: jax.Array | None = None,
   fixed_tokens: jax.Array | None = None,
   tie_group_map: jax.Array | None = None,
+  state_position_map: jax.Array | None = None,
   state_weights: jax.Array | None = None,
   ligand_coords: jax.Array | None = None,
   ligand_atom_types: jax.Array | None = None,
@@ -151,6 +152,15 @@ def build_inference_bundle(
   elif tie_group_map.ndim == 1:
     tie_group_map = jnp.broadcast_to(tie_group_map[None, :], (num_states, seq_len))
 
+  if state_position_map is None:
+    # Identity: reference position i == state s's own native index i (today's
+    # naive, pre-fix behavior). Populate via
+    # aminx.utils.align.build_state_position_map when states have genuinely
+    # different native lengths/numbering.
+    state_position_map = jnp.broadcast_to(jnp.arange(seq_len)[None, :], (num_states, seq_len))
+  elif state_position_map.ndim == 1:
+    state_position_map = jnp.broadcast_to(state_position_map[None, :], (num_states, seq_len))
+
   # 2b. Wave schedule (W0.3).
   #
   # IMPORTANT (jit/vmap safety): `schedule="fixed_n_to_c"` (the default) stays
@@ -228,6 +238,7 @@ def build_inference_bundle(
     fixed_tokens=fixed_tokens if fixed_tokens is not None else jnp.zeros(seq_len, dtype=jnp.int32),
     bias=bias if bias is not None else jnp.zeros((seq_len, 21)),
     tie_group_map=tie_group_map,
+    state_position_map=state_position_map,
     state_weights=state_weights,
     sequence_oh=sequence_oh,
     ar_mask=ar_mask,

--- a/src/aminx/inference/decode/_base.py
+++ b/src/aminx/inference/decode/_base.py
@@ -14,8 +14,11 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
+from aminx.inference.decode._kernel import _realign_states_to_reference
 from aminx.types.bundles import EncoderOutput, InferenceBundle
 from aminx.types.stages import StageSet
+
+_MULTI_STATE_NDIM = 3
 
 
 class _ConditionalDecodeBase(eqx.Module, abc.ABC):
@@ -83,6 +86,7 @@ class _ConditionalDecodeBase(eqx.Module, abc.ABC):
     logits: jnp.ndarray,
     stage_set: StageSet,
     bias: jnp.ndarray | None = None,
+    state_position_map: jnp.ndarray | None = None,
   ) -> jnp.ndarray:
     """Apply logit fusion via stage_set.logit_transform.
 
@@ -96,6 +100,14 @@ class _ConditionalDecodeBase(eqx.Module, abc.ABC):
         Contains logit_transform (may be None for identity).
     bias : ndarray | None, default None
         Optional position-specific bias. Shape (L, V).
+    state_position_map : ndarray | None, default None
+        Per-state gather index into the reference frame, shape (S, L) --
+        see ``ConditioningBundle.state_position_map`` and
+        ``_kernel._realign_states_to_reference``. When provided (and logits is
+        genuinely multi-state, ndim==3), states are realigned to the reference
+        frame before fusion so per-position fusion combines the same physical
+        residue across states, not the same raw array index. None (or a
+        single-state (L, V) input) skips realignment -- pre-fix behavior.
 
     Returns
     -------
@@ -106,6 +118,9 @@ class _ConditionalDecodeBase(eqx.Module, abc.ABC):
     if stage_set.logit_transform is None:
       # Identity: single-state passthrough (already shape (L, V))
       return logits
+
+    if state_position_map is not None and logits.ndim == _MULTI_STATE_NDIM:
+      logits = _realign_states_to_reference(logits, state_position_map)
 
     # logit_transform signature: (S, L, V) + (L, V) -> (L, V)
     return stage_set.logit_transform(logits, bias=bias)

--- a/src/aminx/inference/decode/_kernel.py
+++ b/src/aminx/inference/decode/_kernel.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import PRNGKeyArray
+from jaxtyping import Array, Float, Int, PRNGKeyArray
 
 
 def _decode_one_step(
@@ -168,3 +168,53 @@ def _tied_group_einsum_average(
 
   # Vmap over S axis
   return jax.vmap(average_one_state, in_axes=0)(logits)
+
+
+def _realign_states_to_reference(
+  logits: Float[Array, "S L V"],
+  state_position_map: Int[Array, "S L"],
+) -> Float[Array, "S L V"]:
+  """Gather per-state logits into a shared reference frame before cross-state fusion.
+
+  Reorders each state's own (S, L, V) logits along the L axis via
+  ``state_position_map`` (see ``ConditioningBundle.state_position_map`` and
+  ``aminx.utils.align.build_state_position_map``) so that per-position fusion
+  (``LOGIT_STRATEGIES``'s arithmetic_mean/geometric_mean/product, called
+  immediately after this) combines logits for the same physical residue across
+  states, not the same raw array index. With the default identity
+  ``state_position_map``, this is a no-op (every state's own index i gathers
+  from itself), reproducing pre-fix behavior exactly.
+
+  Gap positions (``state_position_map == -1``, i.e. an indel relative to the
+  reference) are filled with zero logits. This is an exact neutral element for
+  the ``product`` strategy (a weighted *sum* of logits -- a zero contribution
+  from a missing state leaves the sum unchanged, correctly excluding it). It is
+  a documented approximation, not an exact per-position renormalization, for
+  ``arithmetic_mean``/``geometric_mean``: both divide by a fixed,
+  position-independent sum of per-state weights (``LOGIT_STRATEGIES``'s
+  ``weights`` are shape (S,), not position-aware), so a state's zero-logit
+  contribution at a gap still participates in that denominator rather than
+  being excluded from it. Exact renormalization for those two strategies would
+  require making ``LOGIT_STRATEGIES``'s weights position-aware -- out of scope
+  here (the necklace campaign's locked strategy is ``product`` specifically,
+  which this handles exactly; see praxia debt #572/#575).
+
+  Parameters
+  ----------
+  logits : ndarray
+      Per-state logits before cross-state fusion. Shape (S, L, V).
+  state_position_map : ndarray
+      Per-state gather index into the reference frame. Shape (S, L). Entry
+      [s, i] is the index in state s's own native numbering corresponding to
+      reference position i, or -1 for no correspondence (indel).
+
+  Returns
+  -------
+  ndarray
+      Realigned logits, shape (S, L, V), ready for cross-state fusion.
+
+  """
+  is_valid = state_position_map != -1
+  safe_indices = jnp.where(is_valid, state_position_map, 0)
+  gathered = jnp.take_along_axis(logits, safe_indices[..., None], axis=1)
+  return jnp.where(is_valid[..., None], gathered, 0.0)

--- a/src/aminx/inference/decode/autoregressive.py
+++ b/src/aminx/inference/decode/autoregressive.py
@@ -31,6 +31,7 @@ from xtrax.tiling import CarryShape, MapIterator, ScanIterator
 from aminx.inference.decode._kernel import (
   _decode_one_step,
   _project_logits,
+  _realign_states_to_reference,
 )
 from aminx.inference.sample_autoregressive import SampleResult
 from aminx.types.bundles import EncoderOutput, InferenceBundle, WaveScheduleBundle
@@ -291,6 +292,11 @@ class AutoregressiveDecode(eqx.Module):
 
         # Project to logits: (S, L, H) -> (S, L, 21)
         logits = _project_logits(self.model, decoded)
+
+        # Realign states to the shared reference frame before cross-state fusion
+        # (identity state_position_map is a no-op -- pre-fix behavior). See
+        # ConditioningBundle.state_position_map / _kernel._realign_states_to_reference.
+        logits = _realign_states_to_reference(logits, cond.state_position_map)
 
         # Fuse per-position logits across states with and without bias
         # For stored logits: bias-free

--- a/src/aminx/inference/decode/conditional.py
+++ b/src/aminx/inference/decode/conditional.py
@@ -151,5 +151,7 @@ class ConditionalDecode(_ConditionalDecodeBase):
 
     # Fuse across states (S axis) via logit_transform, then across tied positions
     # (L axis) so symmetric-design groups share a single logit distribution (#106).
-    fused_states = self._apply_logit_transform(logits_stack, stage_set, bias=cond.bias)
+    fused_states = self._apply_logit_transform(
+      logits_stack, stage_set, bias=cond.bias, state_position_map=cond.state_position_map,
+    )
     return self._apply_tie_group_fuse(fused_states, stage_set, cond.tie_group_map[0])

--- a/src/aminx/types/bundles.py
+++ b/src/aminx/types/bundles.py
@@ -99,6 +99,17 @@ class ConditioningBundle(eqx.Module):
       Tied-position group assignment. Positions with same group id
       receive same logit distribution (for symmetric design patterns).
       Shape: S = num states.
+  state_position_map : Int[Array, "S L"]
+      Per-state residue correspondence into the shared reference frame (state 0's
+      own numbering). state_position_map[s, i] is the index in state s's native
+      numbering corresponding to reference position i, or -1 if state s has no
+      residue at that reference position (indel). Default is the identity map
+      (state_position_map[s, i] = i for all s), reproducing naive same-index
+      cross-state fusion. Populate via aminx.utils.align.build_state_position_map
+      when states have genuinely different native lengths/numbering (e.g.
+      different PDB depositions of the same protein) so per-position multistate
+      fusion (_apply_logit_transform, ar_logit_transform) combines logits for the
+      same physical residue rather than the same raw array index.
   state_weights : Float[Array, "S"]
       Per-state contribution weights for logit fusion in multi-state models.
       Traced leaf; summed to 1.0 across states before fusion.
@@ -124,6 +135,7 @@ class ConditioningBundle(eqx.Module):
   fixed_tokens: Int[Array, L]
   bias: Float[Array, "L V"]
   tie_group_map: Int[Array, "S L"]
+  state_position_map: Int[Array, "S L"]
   state_weights: Float[Array, S]
   sequence_oh: Float[Array, "L V"]  # zeros for unconditional/AR
   ar_mask: Float[Array, "S L L"]  # full 1s for purely conditional

--- a/src/aminx/utils/align.py
+++ b/src/aminx/utils/align.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
 def smith_waterman_no_gap(unroll_factor: int = 2, *, batch: bool = True) -> Callable:
@@ -598,3 +599,83 @@ def align_sequences(
   masks_b = jnp.arange(max_seq_len) < true_lengths[j_indices][:, None]
 
   return jax.vmap(_align_and_map_pair)(seqs_a, masks_a, seqs_b, masks_b)
+
+
+def build_state_position_map(
+  native_sequences: ProteinSequence | OneHotProteinSequence,
+  reference_state_index: int = 0,
+  gap_open: float = -1.0,
+  gap_extend: float = -0.1,
+  temp: float = 0.1,
+) -> jax.Array:
+  """Build a per-state residue correspondence map into one reference state's frame.
+
+  Star-topology alignment: every state is aligned directly to
+  ``reference_state_index`` via :func:`align_sequences` (no transitive merging of
+  multiple pairwise alignments -- see praxia debt #575 for the deferred, more
+  general n-way case). Intended to populate
+  :attr:`aminx.types.bundles.ConditioningBundle.state_position_map` when states
+  have genuinely different native lengths/numbering (e.g. different PDB
+  depositions of the same protein) so per-position multistate fusion combines
+  logits for the same physical residue rather than the same raw array index.
+
+  This is a host-side, one-time bundle-construction-time utility (analogous to
+  ``WaveScheduleBundle.from_tie_groups``/``from_colors``) -- called once per
+  campaign/bead against the fixed reference structures, not per decode step or
+  per sample, so eager numpy index bookkeeping (rather than a fully traced JAX
+  reduction) is the right tool here.
+
+  Args:
+    native_sequences: Native/backbone amino-acid sequences (or one-hot), one per
+      state, shape (S, L). -1-padded past each state's true native length, per
+      :func:`align_sequences`'s convention.
+    reference_state_index: Which state's own native numbering is the shared
+      reference frame. Its own row of the returned map is always the identity.
+    gap_open: Forwarded to :func:`align_sequences`.
+    gap_extend: Forwarded to :func:`align_sequences`.
+    temp: Forwarded to :func:`align_sequences`.
+
+  Returns:
+    Int array, shape (S, L). ``result[s, i]`` is the index in state ``s``'s own
+    native numbering corresponding to reference position ``i``, or -1 if state
+    ``s`` has no residue there (indel relative to the reference).
+
+  """
+  if native_sequences.dtype == jnp.float32 and native_sequences.ndim == _ONE_HOT_NDIM:
+    native_sequences = jnp.argmax(native_sequences, axis=-1)
+
+  num_states, seq_len = native_sequences.shape
+  identity_row = np.arange(seq_len, dtype=np.int32)
+
+  if num_states < _MINIMUM_PROTEINS_COUNT:
+    return jnp.broadcast_to(jnp.asarray(identity_row)[None, :], (num_states, seq_len))
+
+  pairwise_mappings = np.asarray(
+    align_sequences(native_sequences, gap_open=gap_open, gap_extend=gap_extend, temp=temp),
+  )  # (num_pairs, L, 2); pairs ordered per np.triu_indices(num_states, k=1)
+  pair_i, pair_j = np.triu_indices(num_states, k=1)
+
+  state_position_map = np.tile(identity_row, (num_states, 1))
+
+  for state_idx in range(num_states):
+    if state_idx == reference_state_index:
+      continue
+    lo, hi = min(reference_state_index, state_idx), max(reference_state_index, state_idx)
+    pair_idx = int(np.where((pair_i == lo) & (pair_j == hi))[0][0])
+    mapping = pairwise_mappings[pair_idx]  # (L, 2): [pos_in_lo, pos_in_hi] or [-1, -1]
+
+    row_map = np.full(seq_len, -1, dtype=np.int32)
+    if reference_state_index == lo:
+      # Row r of `mapping` is reference position r; mapping[r, 1] is state_idx's
+      # corresponding position.
+      valid = mapping[:, 0] != -1
+      row_map[mapping[valid, 0]] = mapping[valid, 1]
+    else:
+      # Row r of `mapping` is state_idx's own position r; mapping[r, 1] is the
+      # reference's corresponding position -- invert.
+      valid = mapping[:, 1] != -1
+      row_map[mapping[valid, 1]] = mapping[valid, 0]
+
+    state_position_map[state_idx] = row_map
+
+  return jnp.asarray(state_position_map, dtype=jnp.int32)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,6 +233,7 @@ def minimal_bundle_fixture():
         fixed_tokens=jnp.zeros(L, dtype=jnp.int32),
         bias=jnp.zeros((L, V)),
         tie_group_map=jnp.zeros((S, L), dtype=jnp.int32),
+        state_position_map=jnp.broadcast_to(jnp.arange(L)[None, :], (S, L)),
         state_weights=jnp.ones(S),
         sequence_oh=jnp.zeros((L, V)),
         ar_mask=jnp.ones((S, L, L)),

--- a/tests/host/test_packer_integration.py
+++ b/tests/host/test_packer_integration.py
@@ -131,6 +131,7 @@ def test_inference_plan_decode_with_packer_active():
         fixed_tokens=jnp.zeros(L, dtype=jnp.int32),
         bias=jnp.zeros((L, 21)),
         tie_group_map=jnp.zeros((S, L), dtype=jnp.int32),
+        state_position_map=jnp.broadcast_to(jnp.arange(L)[None, :], (S, L)),
         state_weights=jnp.ones(S),
         sequence_oh=jnp.zeros((L, 21)),
         ar_mask=jnp.ones((S, L, L))
@@ -219,6 +220,7 @@ def test_inference_plan_decode_safety_validation():
         fixed_tokens=jnp.zeros(5, dtype=jnp.int32),
         bias=jnp.zeros((5, 21)),
         tie_group_map=jnp.zeros((1, 5), dtype=jnp.int32),
+        state_position_map=jnp.broadcast_to(jnp.arange(5)[None, :], (1, 5)),
         state_weights=jnp.ones(1),
         sequence_oh=jnp.zeros((5, 21)),
         ar_mask=jnp.ones((1, 5, 5))

--- a/tests/inference/decode/test_autoregressive.py
+++ b/tests/inference/decode/test_autoregressive.py
@@ -542,6 +542,36 @@ def test_autoregressive_with_tied_positions():
     assert result.logits.shape == (L, 21)
 
 
+def test_ar_decode_state_position_map_changes_fused_logits() -> None:
+    """End-to-end: a non-identity state_position_map changes AutoregressiveDecode's
+    fused logits (praxia debt #572's fix) -- this is the actual live generative
+    sampling path the real necklace production run uses, distinct from
+    ConditionalDecode's teacher-forced path (covered separately in
+    test_conditional.py). Compares SampleResult.logits (not the sampled sequence,
+    which is a stochastic categorical draw) under the SAME PRNG key.
+    """
+    num_states, num_residues = 2, 8
+    model, bundle, config = _build_synthetic_fixture(
+        num_states=num_states, num_residues=num_residues, seed=11,
+    )
+    key = jax.random.PRNGKey(0)
+
+    baseline_result = _run_ar_decode(model, bundle, config, key)
+
+    permuted_row = jnp.roll(jnp.arange(num_residues), shift=1)
+    custom_map = jnp.stack([jnp.arange(num_residues), permuted_row])
+    permuted_bundle = eqx.tree_at(
+        lambda b: b.conditioning.state_position_map,
+        bundle,
+        custom_map,
+    )
+    permuted_result = _run_ar_decode(model, permuted_bundle, config, key)
+
+    assert not jnp.allclose(permuted_result.logits, baseline_result.logits), (
+        "state_position_map must actually change AutoregressiveDecode's fused logits"
+    )
+
+
 def test_autoregressive_with_tied_positions_s4():
     """Test AR decode with tied positions (S=4, tied groups)."""
     model, bundle, config = _build_synthetic_fixture(num_states=4, num_residues=12, seed=46)

--- a/tests/inference/decode/test_conditional.py
+++ b/tests/inference/decode/test_conditional.py
@@ -124,3 +124,46 @@ def test_conditional_decode_produces_valid_logits(
     # Verify shape and dtype
     assert logits.shape == (enc.neighbor_indices.shape[1], 21), f"Expected (L, 21), got {logits.shape}"
     assert logits.dtype == jnp.float32
+
+
+def test_conditional_decode_state_position_map_changes_fused_output() -> None:
+    """End-to-end: a non-identity state_position_map actually changes fusion output.
+
+    Confirms the wire-through from build_inference_bundle -> ConditioningBundle ->
+    ConditionalDecode._apply_logit_transform (debt #572's fix) is live, not silently
+    ignored. Complements the exact-math unit tests in
+    tests/inference/decode/test_kernel.py::TestRealignStatesToReference.
+    """
+    num_states, num_residues = 2, 8
+    model, coords, mask, residue_index, chain_index, sequence_oh, bundle, config = (
+        _build_synthetic_fixture(num_states=num_states, num_residues=num_residues, seed=7)
+    )
+
+    k_enc, k_dec = jax.random.split(jax.random.PRNGKey(0))
+    encode_fn = make_encode_fn(model, use_rolling_state=False)
+    enc = encode_fn(bundle, k_enc, config)
+    stage_set = make_stage_set(
+        strategy="arithmetic_mean",
+        state_weights=bundle.conditioning.state_weights,
+    )
+    cond_decode = ConditionalDecode(model=model, state_iterator=VmapIterator())
+
+    baseline_logits = cond_decode(key=k_dec, enc=enc, bundle=bundle, config=config, stage_set=stage_set)
+
+    # Reference state (0) stays identity; state 1's row is a real permutation
+    # (no -1 gaps -- gap handling is covered separately at the kernel unit-test level).
+    permuted_row = jnp.roll(jnp.arange(num_residues), shift=1)
+    custom_map = jnp.stack([jnp.arange(num_residues), permuted_row])
+    permuted_bundle = eqx.tree_at(
+        lambda b: b.conditioning.state_position_map,
+        bundle,
+        custom_map,
+    )
+
+    permuted_logits = cond_decode(
+        key=k_dec, enc=enc, bundle=permuted_bundle, config=config, stage_set=stage_set,
+    )
+
+    assert not jnp.allclose(permuted_logits, baseline_logits), (
+        "state_position_map must actually change ConditionalDecode's fused output"
+    )

--- a/tests/inference/decode/test_kernel.py
+++ b/tests/inference/decode/test_kernel.py
@@ -14,6 +14,7 @@ from aminx.model import Aminx
 from aminx.inference.decode._kernel import (
     _decode_one_step,
     _project_logits,
+    _realign_states_to_reference,
     _tied_group_einsum_average,
 )
 from aminx.types.bundles import EncoderOutput, ConditioningBundle
@@ -252,3 +253,73 @@ class TestTiedGroupEinsumAverage:
 
         # Verify first state matches
         assert jnp.allclose(averaged[0], expected_first_state, atol=1e-6)
+
+
+class TestRealignStatesToReference:
+    """Tests for _realign_states_to_reference (cross-state PoE alignment, debt #572)."""
+
+    def test_identity_map_is_noop(self):
+        """Identity state_position_map reproduces pre-fix (naive) behavior exactly."""
+        S, L, V = 3, 10, 21
+        key = jax.random.PRNGKey(0)
+        logits = jax.random.normal(key, (S, L, V))
+        identity_map = jnp.broadcast_to(jnp.arange(L)[None, :], (S, L))
+
+        realigned = _realign_states_to_reference(logits, identity_map)
+
+        assert jnp.array_equal(realigned, logits)
+
+    def test_known_insertion_gathers_correct_residue(self):
+        """A state with a known single-residue insertion realigns to the intended positions.
+
+        Reference (state 0): positions 0..4. State 1 has an extra residue inserted at
+        its own position 2 -- so state 1's position 3 is the one that actually
+        corresponds to reference position 2 (matches the build_state_position_map
+        smoke test in this session: MKVLA vs MK-D-VLA).
+        """
+        L, V = 6, 21
+        key = jax.random.PRNGKey(1)
+        state0_logits = jax.random.normal(key, (L, V))
+        state1_logits = jax.random.normal(jax.random.PRNGKey(2), (L, V))
+        logits = jnp.stack([state0_logits, state1_logits], axis=0)  # (2, L, V)
+
+        # Matches this session's build_state_position_map smoke test result exactly.
+        state_position_map = jnp.array([
+            [0, 1, 2, 3, 4, 5],
+            [0, 1, 3, 4, 5, -1],
+        ])
+
+        realigned = _realign_states_to_reference(logits, state_position_map)
+
+        assert realigned.shape == (2, L, V)
+        # State 0 (reference) is untouched.
+        assert jnp.array_equal(realigned[0], state0_logits)
+        # State 1's reference position 2 must pull from its OWN position 3, not 2.
+        assert jnp.allclose(realigned[1, 2], state1_logits[3])
+        assert jnp.allclose(realigned[1, 3], state1_logits[4])
+        assert jnp.allclose(realigned[1, 4], state1_logits[5])
+        # Naive (buggy) same-index fusion would have used state1_logits[2] here --
+        # explicitly assert the fix actually changed the result, not just shape.
+        assert not jnp.allclose(realigned[1, 2], state1_logits[2])
+
+    def test_gap_position_zeroed(self):
+        """A reference position with no correspondence in a state (-1) is zero-filled.
+
+        Zero is an exact neutral element for the 'product' strategy (a sum of
+        logits) -- see _realign_states_to_reference's docstring for the documented
+        (non-exact) approximation this represents for arithmetic_mean/geometric_mean.
+        """
+        L, V = 4, 21
+        logits = jax.random.normal(jax.random.PRNGKey(3), (2, L, V))
+        state_position_map = jnp.array([
+            [0, 1, 2, 3],
+            [0, 1, -1, 3],  # state 1 has no residue at reference position 2
+        ])
+
+        realigned = _realign_states_to_reference(logits, state_position_map)
+
+        assert jnp.array_equal(realigned[1, 2], jnp.zeros(V))
+        # Non-gap positions for state 1 are untouched (identity there).
+        assert jnp.array_equal(realigned[1, 0], logits[1, 0])
+        assert jnp.array_equal(realigned[1, 1], logits[1, 1])
+        assert jnp.array_equal(realigned[1, 3], logits[1, 3])

--- a/tests/inference/decode/test_unconditional.py
+++ b/tests/inference/decode/test_unconditional.py
@@ -75,6 +75,7 @@ def _build_synthetic_fixture(
         fixed_tokens=jnp.zeros((L,), dtype=jnp.int32),
         bias=bias,
         tie_group_map=jnp.zeros((num_states, L), dtype=jnp.int32),
+        state_position_map=jnp.broadcast_to(jnp.arange(L)[None, :], (num_states, L)),
         state_weights=jnp.ones((num_states,)) / num_states,
         sequence_oh=jnp.zeros((L, 21)),  # zeros for unconditional
         ar_mask=jnp.ones((num_states, L, L)),  # full 1s for non-AR

--- a/tests/inference/test_vmap_axis_contract.py
+++ b/tests/inference/test_vmap_axis_contract.py
@@ -170,6 +170,7 @@ def make_minimal_bundle(L: int = 4, S: int = 1) -> InferenceBundle:
         fixed_tokens=jnp.zeros((L,), dtype=jnp.int32),
         bias=jnp.zeros((L, V)),
         tie_group_map=jnp.arange(L)[None, :].repeat(S, axis=0),
+        state_position_map=jnp.arange(L)[None, :].repeat(S, axis=0),
         state_weights=jnp.ones((S,)) / S,
         sequence_oh=jnp.zeros((L, V)),
         ar_mask=jnp.ones((S, L, L)),

--- a/tests/utils/test_align.py
+++ b/tests/utils/test_align.py
@@ -6,6 +6,7 @@ import pytest
 
 from aminx.utils.align import (
     align_sequences,
+    build_state_position_map,
     needleman_wunsch_alignment,
     smith_waterman,
     smith_waterman_affine,
@@ -135,3 +136,60 @@ class TestAlignments(chex.TestCase):
         alignment = align_fn(seqs)
         chex.assert_shape(alignment, (0, 0, 2))
         chex.assert_tree_all_finite(alignment)
+
+
+class TestBuildStatePositionMap:
+    """Tests for build_state_position_map (praxia debt #572's alignment builder).
+
+    Host-side, eager-numpy utility -- not jit-traced, so no chex.variants here
+    (matches _realign_states_to_reference's caller-side identity/gap contract in
+    tests/inference/decode/test_kernel.py::TestRealignStatesToReference).
+    """
+
+    # BLOSUM62 column order (see align.py's _AA_SCORE_MATRIX docstring):
+    # A,R,N,D,C,Q,E,G,H,I,L,K,M,F,P,S,T,W,Y,V
+    _M, _K, _V, _L, _A, _D = 12, 11, 19, 10, 0, 3
+
+    def test_identical_sequences_are_pure_identity(self):
+        """Two identical native sequences map to the identity in both directions."""
+        seq = jnp.array([self._M, self._K, self._V, self._L, self._A])
+        seqs = jnp.stack([seq, seq])
+
+        result = build_state_position_map(seqs, reference_state_index=0)
+
+        chex.assert_shape(result, (2, 5))
+        assert jnp.array_equal(result[0], jnp.arange(5))
+        assert jnp.array_equal(result[1], jnp.arange(5))
+
+    def test_single_insertion_recovered_reference_as_seq_a(self):
+        """Reference (index 0) vs a state with one inserted residue (D at position 2)."""
+        ref = jnp.array([self._M, self._K, self._V, self._L, self._A, -1])
+        inserted = jnp.array([self._M, self._K, self._D, self._V, self._L, self._A])
+        seqs = jnp.stack([ref, inserted])
+
+        result = build_state_position_map(seqs, reference_state_index=0)
+
+        assert jnp.array_equal(result[0], jnp.arange(6))
+        # Reference position 2 (V) is at the inserted state's position 3, not 2.
+        expected_row1 = jnp.array([0, 1, 3, 4, 5, -1])
+        assert jnp.array_equal(result[1], expected_row1)
+
+    def test_single_state_returns_identity(self):
+        """Fewer than 2 states: no alignment possible, returns the identity map."""
+        seqs = jnp.array([[self._M, self._K, self._V, self._L, self._A]])
+
+        result = build_state_position_map(seqs, reference_state_index=0)
+
+        assert jnp.array_equal(result[0], jnp.arange(5))
+
+    def test_non_zero_reference_state_index(self):
+        """Reference need not be state 0 -- its own row must still be the identity."""
+        ref = jnp.array([self._M, self._K, self._V, self._L, self._A, -1])
+        inserted = jnp.array([self._M, self._K, self._D, self._V, self._L, self._A])
+        seqs = jnp.stack([inserted, ref])  # reference is index 1 this time
+
+        result = build_state_position_map(seqs, reference_state_index=1)
+
+        assert jnp.array_equal(result[1], jnp.arange(6))
+        expected_row0 = jnp.array([0, 1, 3, 4, 5, -1])
+        assert jnp.array_equal(result[0], expected_row0)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aminx"
-version = "0.1.0a11"
+version = "0.1.0a12"
 source = { editable = "." }
 dependencies = [
     { name = "array-record", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary
Fixes praxia debt #572: multistate fusion (`multi_state_strategy="product"`/`"arithmetic_mean"`/`"geometric_mean"`) combined per-state logits by **raw array index**, implicitly assuming position *i* means the same physical residue across all S states. That assumption is false whenever states have genuinely different native lengths/numbering (e.g. different PDB depositions of the same protein) — confirmed on the necklace campaign's locked k=4 states, which range 214–235 residues after correctly-applied chain filtering (debt #554's fix verified working — not a dimer-inclusion bug, a real alignment gap).

- **`ConditioningBundle.state_position_map`** (`types/bundles.py`) — new field, per-state gather index into a shared reference frame (state 0's own numbering). `-1` marks no correspondence (indel). Defaults to the identity map in `build_inference_bundle` (mirrors `tie_group_map`'s existing resolution pattern) — reproduces pre-fix behavior exactly for any caller that doesn't populate it.
- **`build_state_position_map`** (`utils/align.py`) — builder using the existing `align_sequences()` Smith-Waterman primitive, which had exactly one (unrelated) caller in the whole codebase before this. Star-topology: every state aligned directly to one reference state. N-way transitive merging of multiple pairwise alignments is deferred as low-priority xtrax-scoped debt (#575) — not needed for this fix.
- **`_realign_states_to_reference`** (`_kernel.py`) — gathers each state's logits into the reference frame before fusion; gap positions zero-filled (exact neutral element for `product`, a documented approximation for `arithmetic_mean`/`geometric_mean` — see its docstring for why exact renormalization there is out of scope). Wired into **both** real fusion call sites: `ConditionalDecode._apply_logit_transform` (teacher-forced scoring) and `AutoregressiveDecode`'s `do_sample` closure — the actual live generative sampling path the necklace campaign's real production run uses.

This session's `decode_states_unfused`/`mbr_rerank` (MBR consensus reranking, #95) does not need this fix — it reduces to a per-state scalar NLL before any cross-state averaging, so position alignment doesn't apply there.

## Test plan
- [x] Unit tests: `_realign_states_to_reference` (identity no-op, known-insertion gather, gap zero-fill) — `tests/inference/decode/test_kernel.py`
- [x] Builder tests: `build_state_position_map` (identical sequences, single insertion from both alignment directions, single-state edge case, non-zero reference index) — `tests/utils/test_align.py`
- [x] End-to-end integration tests confirming the wiring is live (not silently ignored) through both real call sites — `test_conditional_decode_state_position_map_changes_fused_output`, `test_ar_decode_state_position_map_changes_fused_logits`
- [x] `uv run pytest tests/inference/ tests/sampling/ tests/host/ tests/utils/ tests/types/ tests/run/ -q` — 951 passed, 0 regressions
- [x] `jaxlint check` on all changed files — zero new findings relative to origin/main baseline