### PR TITLE
chore: bump version 0.1.0a12 -> 0.1.0a13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a12"
+version = "0.1.0a13"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
Bumps for the cross-state residue alignment fix (#97), so tev_design can vendor a wheel that includes it.