### PR TITLE
feat(sampling): wire multi-state PoE sampling into the campaign pipeline

### DIFF
--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -30,6 +30,7 @@ from xtrax.run import (
 # campaign manifest functions are implemented in this module (see build_manifest_row et al.)
 from aminx.host.runner import sample
 from aminx.run.specs import SamplingSpecification, pop_deprecated_spec_kwargs
+from aminx.sampling.multistate_poe import sample_multistate_poe_campaign_row
 from aminx.runtime import configure_multiprocessing
 
 if TYPE_CHECKING:
@@ -848,8 +849,22 @@ def run_manifest_row(  # noqa: PLR0915
     worker_payload["output_h5_path"] = str(partial_path)
     pop_deprecated_spec_kwargs(worker_payload)
     sampling_spec = SamplingSpecification(**worker_payload)
+    # Genuine multi-state PoE rows (len(inputs) > 1) route to
+    # sample_multistate_poe_campaign_row instead of sample() -- sample()'s real dispatcher
+    # (_sample_batch) treats every --inputs path as an independent single-state structure and
+    # never actually fuses states (praxia debt #572 follow-up, decisions/
+    # 260713_no-real-multistate-sampling-path-exists.md). Single-structure ("spike-in") rows
+    # are unaffected -- len(inputs) == 1 for those, so they keep going through sample() exactly
+    # as before.
+    is_multistate_poe_row = (
+      isinstance(sampling_spec.inputs, (list, tuple)) and len(sampling_spec.inputs) > 1
+    )
     try:
-      sample_result = sample(sampling_spec)
+      sample_result = (
+        sample_multistate_poe_campaign_row(sampling_spec)
+        if is_multistate_poe_row
+        else sample(sampling_spec)
+      )
       if heartbeat_errors:
         msg = (
           f"Lock heartbeat failed while executing manifest row {manifest_hash}: "

--- a/src/aminx/sampling/multistate_poe.py
+++ b/src/aminx/sampling/multistate_poe.py
@@ -18,26 +18,56 @@ per-structure_idx slicing loop) and samples from it via `aminx.inference.sample_
 which already correctly wires `AutoregressiveMode` and genuinely fuses an `S>1` state axis
 (confirmed by the existing `test_ar_decode_state_position_map_changes_fused_logits` test).
 
-Does NOT touch `_sample_batch`/`kernel_dispatch.py`, `campaign.py`, or `bundle_builder.py` --
-every existing campaign row (single-structure spike-in beads) is unaffected. Does not wire into
-`aminx campaign plan/run`'s CLI or manifest/Zarr-writer machinery; that integration (and the more
-general, xtrax-composable arbitrary-fusion-axis version of this idea) is real, separate follow-up
-work, tracked as praxia debt #589.
+Does NOT touch `_sample_batch`/`kernel_dispatch.py`, or `bundle_builder.py` -- every existing
+campaign row (single-structure spike-in beads) is unaffected.
+
+`sample_multistate_poe_campaign_row` (added 2026-07-14) wires this into `aminx campaign
+plan/run`'s execution path: `host/campaign.py::run_manifest_row` detects a genuine multi-state
+PoE row (`len(sampling_spec.inputs) > 1`) and calls it instead of `sample()`, so real campaign
+manifests actually produce fused output through the normal `aminx campaign run` CLI, retaining
+the surrounding locking/done-marker/retry/resumability infrastructure unchanged. It writes via
+`xtrax.run.ZarrStagingSink`/`SinkSpec` -- the same Sink primitive `host/streaming.py::
+_sample_streaming` uses -- matching that function's campaign-mode attrs/schema convention as
+closely as the fused (not per-structure) output shape allows. The more general,
+xtrax-composable arbitrary-fusion-axis version of the *underlying dispatch itself* (option 2
+from the decision doc, a real `N_POE_STATES`-style `AxisSpec`) remains real, separate follow-up
+work, tracked as praxia debt #589 -- this campaign wiring does not close that debt, it just makes
+option 1's MVP actually reachable from a real campaign run.
 """
 
 from __future__ import annotations
 
+import dataclasses
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
+from xtrax.run import SinkSpec, ZarrStagingSink
 
-from aminx.host._sampling_helper import _prepare_fixed_controls, _prepare_ligand_context
+from aminx.host._sampling_grid_lineage import (
+  _base_sampling_key,
+  _grid_iteration_arrays,
+  _grid_manifest_row_hash,
+  _grid_sample_indices,
+  _resolve_grid_lineage,
+)
+from aminx.host._sampling_helper import (
+  _canonical_structure_ids_for_spec,
+  _prepare_fixed_controls,
+  _prepare_ligand_context,
+)
+from aminx.host.plan import resolve_chunk_size, resolve_sample_start, resolve_target_samples
 from aminx.host.prep import prep_protein_stream_and_model
+from aminx.host.streaming import GRID_SCHEMA_VERSION, SAMPLING_SCHEMA_VERSION, _grid_lineage_attrs
 from aminx.inference.bundle_builder import build_inference_bundle
 from aminx.inference.logits import make_stage_set
 from aminx.inference.sample_autoregressive import kernel as _sample_autoregressive_kernel
+from aminx.sampling.conditional_logits import _plan_axis_strategy
+from aminx.tiling.axes import N_SAMPLES
+from aminx.tiling.dispatch import make_axis_dispatch_via_xtrax
 
 if TYPE_CHECKING:
   from jaxtyping import Array, Float, Int, PRNGKeyArray
@@ -49,7 +79,6 @@ if TYPE_CHECKING:
   from aminx.types.stages import StageSet
 
 
-@eqx.filter_jit
 def sample_states_fused(
   model: Aminx,
   bundle: InferenceBundle,
@@ -57,11 +86,24 @@ def sample_states_fused(
   stage_set: StageSet,
   prng_key: PRNGKeyArray,
   n_samples: int,
+  sample_batch_size: int | None = None,
 ) -> tuple[Int[Array, "n_samples L"], Float[Array, "n_samples L 21"]]:
   """Draw n_samples independent samples from an already-built, already-fused bundle.
 
-  Thin vmap wrapper around `aminx.inference.sample_autoregressive.kernel` -- the genuine,
-  already-tested `AutoregressiveMode` sampling path, which fuses `bundle`'s own state axis
+  Dispatches the sample-key axis via the same composable_jax idiom every other axis in this
+  package uses -- `_plan_axis_strategy` (`aminx.sampling.conditional_logits`) resolves a real
+  `xtrax.tiling.BatchPlanner` decision (Vmap when `n_samples` fits the device memory budget,
+  SafeMap-chunked otherwise) against the existing `N_SAMPLES` `AxisSpec`
+  (`aminx.tiling.axes`), then `make_axis_dispatch_via_xtrax` turns that decision into a typed
+  iterator -- exactly how `make_batched_conditional_logits_split_fn` dispatches
+  `N_REPLICATES`/`N_CANDIDATES` (`conditional_logits.py:390-397,421-427`). Deliberately not a
+  bare `jax.vmap`: a fixed `jax.vmap` over an unbounded `n_samples` would attempt every sample
+  in one shot regardless of the device's actual memory, exactly the failure mode
+  `_plan_axis_strategy`'s `BatchPlanner`/`MemoryBudget` exists to prevent for large campaign-
+  scale sample counts (thousands of samples per bead).
+
+  Calls `aminx.inference.sample_autoregressive.kernel` -- the genuine, already-tested
+  `AutoregressiveMode` sampling path, which fuses `bundle`'s own state axis
   (`bundle.geometry.n_states`) via `stage_set.logit_transform`/`_realign_states_to_reference`
   exactly as `ConditionalDecode`'s teacher-forced scoring path does. Each sample gets its own
   PRNG key (`jax.random.split`); `bundle`/`config`/`stage_set` are shared and re-encoded once
@@ -83,6 +125,11 @@ def sample_states_fused(
       Base key; split into `n_samples` independent per-sample keys.
   n_samples : int
       Number of independent samples to draw.
+  sample_batch_size : int | None, default None
+      Fixed SafeMap tile size for the sample axis. None defers to the BatchPlanner's
+      memory-budget-driven Vmap/SafeMap choice, matching
+      `make_batched_conditional_logits_split_fn`'s `replicate_batch_size`/
+      `candidate_batch_size` default behavior.
 
   Returns
   -------
@@ -93,11 +140,27 @@ def sample_states_fused(
   """
   sample_keys = jax.random.split(prng_key, n_samples)
 
+  seq_len = bundle.geometry.coords.shape[1]
+  num_states = bundle.geometry.coords.shape[0]
+  # Conservative per-sample activation estimate: per-state decode features (node+edge,
+  # float32) scaled by num_states, plus the (L, 21) logits output -- mirrors the
+  # replicate-axis estimate in conditional_logits.py:390, scaled for the extra state axis
+  # AR sampling carries that encode-only replicate estimation doesn't.
+  activation_bytes = num_states * seq_len * (128 + 32 * 48) * 4
+  strategy = _plan_axis_strategy(
+    N_SAMPLES,
+    n_samples,
+    sample_batch_size,
+    activation_bytes_per_element=activation_bytes,
+  )
+  iterator = make_axis_dispatch_via_xtrax(strategy, axis=N_SAMPLES.name)
+
+  @eqx.filter_jit
   def _one_sample(key: PRNGKeyArray) -> tuple[Any, Any]:
     result = _sample_autoregressive_kernel(model, key, bundle, config, stage_set)
     return result.sequence, result.logits
 
-  sequences, logits = jax.vmap(_one_sample)(sample_keys)
+  sequences, logits = iterator(_one_sample, sample_keys)
   return sequences, logits
 
 
@@ -289,3 +352,198 @@ def sample_multistate_poe_bead(
   )
 
   return sample_states_fused(model, bundle, config, stage_set, prng_key, n_samples)
+
+
+def sample_multistate_poe_campaign_row(spec: SamplingSpecification) -> dict[str, Any]:
+  """Execute one campaign manifest row as a genuine multi-state PoE bead.
+
+  Real integration point for `host/campaign.py::run_manifest_row`: called INSTEAD of
+  `host/runner.py::sample()` for rows where `len(spec.inputs) > 1` (a genuine multi-state PoE
+  bead), so `aminx campaign run` produces real fused output for these rows rather than
+  `_sample_batch`'s per-structure-independent output. Single-structure ("spike-in") rows are
+  untouched -- they still go through `sample()`/`_sample_batch` exactly as before; this function
+  is never called for them.
+
+  Writes to `spec.run_spec.io.output_h5_path` via `xtrax.run.ZarrStagingSink`/`SinkSpec` -- the
+  same Sink primitive `host/streaming.py::_sample_streaming` uses -- so
+  `run_manifest_row`'s surrounding done-marker/lock/retry machinery (which only cares that
+  `output_h5_path` gets populated and content-digested, not which function populated it) works
+  completely unchanged. The written schema mirrors `_sample_streaming`'s campaign-mode attrs
+  as closely as a genuinely fused (not per-structure) result allows: ONE Zarr group
+  (`"poe_fused"`) replaces the `structure_0..structure_{k-1}` groups `_sample_streaming` would
+  otherwise write for this many `--inputs`, since there is no longer "k independent structures"
+  to store -- states are fused into one design series per sample.
+
+  Resolves the real campaign chunk/sample-count/lineage axes via the SAME helpers
+  `_sample_streaming` uses (`resolve_target_samples`/`resolve_chunk_size`/`resolve_sample_start`/
+  `_resolve_grid_lineage`), so chunked resubmission (`samples_chunk_size`, necklace's real
+  SAMPLES_CHUNK_SIZE=20 convention) and grid-lineage manifest-row-hash bookkeeping behave
+  identically to every other row. Derives its base PRNG key via the same
+  `_base_sampling_key(spec, grid_lineage=...)` helper (keyed off `spec.run_spec.sampling.
+  random_seed` + grid lineage), matching this campaign's real determinism/reproducibility
+  convention -- NOT bit-identical to `_sample_batch`'s own per-sample `compute_sample_keys`
+  fold-in scheme (a deliberately separate code path, not meant to reproduce that scheme
+  key-for-key; only the SEED derivation matches, not every downstream fold_in step).
+
+  Handles `spec.run_spec.sampling.temperature`/`backbone_noise` as real grid axes (each real
+  necklace PoE row uses 5 temperatures x 1 noise level): loops over every (noise, temperature)
+  combination, building a per-cell `SamplingSpecification` via `dataclasses.replace` (confirmed
+  to correctly re-sync the nested `run_spec.sampling.{temperature,backbone_noise}` fields, not
+  just the flat ones) and calling `sample_multistate_poe_bead` once per cell -- this means
+  `prep_protein_stream_and_model` (the real PDB parsing/padding/chain-filtering step) reruns
+  once per (noise, temperature) cell rather than once total. This is a known, deliberate
+  correctness-first tradeoff, not an oversight: real necklace rows have 5 temperatures x 1
+  noise = 5 redundant structure reloads per row, cheap relative to the AR sampling compute
+  itself. Refactoring to load structures once and reuse across cells is a real, tracked
+  follow-up optimization if profiling ever shows this reload cost matters at production scale --
+  not applied here to keep this integration's first version small and easy to verify correct.
+
+  Parameters
+  ----------
+  spec : SamplingSpecification
+      Real campaign row spec (as `run_manifest_row` constructs via
+      `SamplingSpecification(**worker_payload)`) -- must have `len(spec.inputs) > 1` and
+      `spec.batch_size == len(spec.inputs)` (same precondition as `sample_multistate_poe_bead`).
+
+  Returns
+  -------
+  dict
+      Matches `sample()`'s streaming-mode return contract: `output_zarr_path`,
+      `schema_version`, `metadata` (with `specification`, `skipped_inputs`, `structure_ids`,
+      and `lineage` if grid_mode). `run_manifest_row` merges this into its own result payload
+      exactly as it does for `sample()`'s return value.
+
+  Raises
+  ------
+  ValueError
+      If `spec.inputs` has fewer than 2 entries (same precondition as
+      `sample_multistate_poe_bead`; this function should only ever be called for genuine
+      multi-state rows, but re-asserts the precondition rather than trusting the caller).
+
+  """
+  if not isinstance(spec.inputs, (list, tuple)) or len(spec.inputs) < 2:
+    msg = (
+      f"sample_multistate_poe_campaign_row needs >=2 states in spec.inputs to fuse across "
+      f"(got {spec.inputs!r}) -- single-structure rows must go through sample() instead."
+    )
+    raise ValueError(msg)
+
+  grid_lineage = _resolve_grid_lineage(spec)
+  canonical_structure_ids = _canonical_structure_ids_for_spec(spec)
+  total_num_samples = resolve_target_samples(spec, grid_lineage=grid_lineage)
+  chunk_size = resolve_chunk_size(spec, total_num_samples, grid_lineage)
+  base_key = _base_sampling_key(spec, grid_lineage=grid_lineage)
+
+  temperature_val = spec.run_spec.sampling.temperature
+  temperatures = (
+    list(temperature_val) if isinstance(temperature_val, (list, tuple)) else [temperature_val]
+  )
+  noise_val = spec.run_spec.sampling.backbone_noise
+  noises = list(noise_val) if isinstance(noise_val, (list, tuple)) else [noise_val]
+  return_logits = spec.run_spec.sampling.return_logits
+
+  sequence_rows: list[list[np.ndarray]] = []
+  logits_rows: list[list[np.ndarray]] = []
+  seq_len: int | None = None
+  for noise_idx, noise in enumerate(noises):
+    sequence_row: list[np.ndarray] = []
+    logits_row: list[np.ndarray] = []
+    for temp_idx, temperature in enumerate(temperatures):
+      cell_key = jax.random.fold_in(jax.random.fold_in(base_key, noise_idx), temp_idx)
+      cell_spec = dataclasses.replace(
+        spec, backbone_noise=[noise], temperature=[temperature],
+      )
+      cell_sequences, cell_logits = sample_multistate_poe_bead(
+        cell_spec, cell_key, n_samples=chunk_size,
+      )
+      cell_sequences_np = np.asarray(jax.device_get(cell_sequences), dtype=np.int32)
+      cell_logits_np = np.asarray(jax.device_get(cell_logits), dtype=np.float32)
+      if seq_len is None:
+        seq_len = cell_sequences_np.shape[-1]
+      sequence_row.append(cell_sequences_np)
+      logits_row.append(cell_logits_np)
+    sequence_rows.append(sequence_row)
+    logits_rows.append(logits_row)
+
+  # sequence_rows[noise_idx][temp_idx] has shape (chunk_size, L) -- stack into the
+  # (chunk_size, num_noise, num_temperatures, L) convention _sample_streaming's campaign-mode
+  # schema uses, so a reader (e.g. a future necklace_zarr_reader.py) sees the same axis order
+  # regardless of whether a row is fused or per-structure.
+  sequences_arr = np.stack(
+    [np.stack(row, axis=1) for row in sequence_rows], axis=1,
+  )  # (chunk_size, num_noise, num_temperatures, L)
+  logits_arr = (
+    np.stack([np.stack(row, axis=1) for row in logits_rows], axis=1)
+    if return_logits
+    else None
+  )  # (chunk_size, num_noise, num_temperatures, L, 21)
+
+  output_dir = Path(spec.run_spec.io.output_h5_path)
+  sink = ZarrStagingSink(SinkSpec(output_dir=output_dir, format="zarr", flush_every=1))
+
+  root_attrs: dict[str, Any] = {
+    "schema_version": GRID_SCHEMA_VERSION if spec.grid_mode else SAMPLING_SCHEMA_VERSION,
+    "model_family": spec.model_family,
+    "ligand_conditioning": int(spec.ligand_conditioning),
+    "sidechain_conditioning": int(spec.sidechain_conditioning),
+    "samples_chunk_size": chunk_size,
+    "multistate_poe_fused": 1,
+  }
+  root_arrays: dict[str, np.ndarray] = {}
+  if grid_lineage is not None:
+    manifest_row_hash = _grid_manifest_row_hash(spec, grid_lineage)
+    root_attrs.update(_grid_lineage_attrs(grid_lineage))
+    root_attrs["manifest_row_hash"] = manifest_row_hash
+    iteration_ids, iteration_starts, iteration_counts = _grid_iteration_arrays(
+      grid_lineage, chunk_size=chunk_size,
+    )
+    root_arrays = {
+      "sample_indices": _grid_sample_indices(grid_lineage),
+      "grid_iteration_ids": iteration_ids,
+      "grid_iteration_sample_start": iteration_starts,
+      "grid_iteration_sample_count": iteration_counts,
+    }
+  sink.stage((), attrs=root_attrs, **root_arrays)
+
+  key = ("poe_fused",)
+  arrays: dict[str, np.ndarray] = {"sequences": sequences_arr}
+  if logits_arr is not None:
+    arrays["logits"] = logits_arr
+  attrs: dict[str, Any] = {
+    "structure_index": 0,
+    "structure_id": "poe_fused",
+    "fused_structure_ids": list(canonical_structure_ids),
+    "num_samples": chunk_size,
+    "num_noise_levels": len(noises),
+    "num_temperatures": len(temperatures),
+    "sequence_length": int(seq_len),
+  }
+  if grid_lineage is not None:
+    attrs.update(_grid_lineage_attrs(grid_lineage))
+  sink.stage(key, attrs=attrs, **arrays)
+  sink.drain()
+
+  results: dict[str, Any] = {
+    "output_zarr_path": str(output_dir),
+    "schema_version": GRID_SCHEMA_VERSION if spec.grid_mode else SAMPLING_SCHEMA_VERSION,
+    "metadata": {
+      "specification": spec,
+      "skipped_inputs": [],
+      "structure_ids": ["poe_fused"],
+      "fused_structure_ids": list(canonical_structure_ids),
+    },
+  }
+  if grid_lineage is not None:
+    manifest_row_hash = _grid_manifest_row_hash(spec, grid_lineage)
+    iteration_ids, iteration_starts, iteration_counts = _grid_iteration_arrays(
+      grid_lineage, chunk_size=chunk_size,
+    )
+    results["metadata"]["lineage"] = {
+      **grid_lineage,
+      "manifest_row_hash": manifest_row_hash,
+      "sample_indices": _grid_sample_indices(grid_lineage).tolist(),
+      "grid_iteration_ids": iteration_ids.tolist(),
+      "grid_iteration_sample_start": iteration_starts.tolist(),
+      "grid_iteration_sample_count": iteration_counts.tolist(),
+    }
+  return results

--- a/src/aminx/sampling/multistate_poe.py
+++ b/src/aminx/sampling/multistate_poe.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
   from aminx.types.stages import StageSet
 
 
+@eqx.filter_jit
 def sample_states_fused(
   model: Aminx,
   bundle: InferenceBundle,
@@ -155,7 +156,6 @@ def sample_states_fused(
   )
   iterator = make_axis_dispatch_via_xtrax(strategy, axis=N_SAMPLES.name)
 
-  @eqx.filter_jit
   def _one_sample(key: PRNGKeyArray) -> tuple[Any, Any]:
     result = _sample_autoregressive_kernel(model, key, bundle, config, stage_set)
     return result.sequence, result.logits
@@ -385,6 +385,21 @@ def sample_multistate_poe_campaign_row(spec: SamplingSpecification) -> dict[str,
   fold-in scheme (a deliberately separate code path, not meant to reproduce that scheme
   key-for-key; only the SEED derivation matches, not every downstream fold_in step).
 
+  CRITICAL (found by independent PR audit, 2026-07-14): `_base_sampling_key`'s own hash
+  (`_grid_job_seed_hash`) is keyed off `job_id` + strategy/conditioning fields -- it does NOT
+  incorporate `chunk_id`/`sample_start`. A bead whose real design count exceeds
+  `samples_chunk_size` (necklace's real SAMPLES_CHUNK_SIZE=20 -- i.e. any bead with more than
+  20 designs, which is the real production target, not the current placeholder default) is
+  split into MULTIPLE manifest rows sharing one `job_id` but different `chunk_id`/
+  `sample_start` (`build_necklace_p2_manifest.py`'s real chunking). Without folding
+  `sample_start` into the key, every chunk of the same job would derive the IDENTICAL base key
+  and produce byte-identical duplicated samples -- this was caught before it could ship: this
+  function explicitly folds `resolve_sample_start(grid_lineage)` into `base_key` below before
+  any per-cell derivation, specifically so different chunks of the same job produce genuinely
+  different (not duplicated) samples. Do not remove this fold_in as "redundant" without adding
+  an equivalent safeguard -- see the regression test asserting two rows with the same job_id
+  but different chunk_id/sample_start produce distinct sequences.
+
   Handles `spec.run_spec.sampling.temperature`/`backbone_noise` as real grid axes (each real
   necklace PoE row uses 5 temperatures x 1 noise level): loops over every (noise, temperature)
   combination, building a per-cell `SamplingSpecification` via `dataclasses.replace` (confirmed
@@ -393,10 +408,15 @@ def sample_multistate_poe_campaign_row(spec: SamplingSpecification) -> dict[str,
   `prep_protein_stream_and_model` (the real PDB parsing/padding/chain-filtering step) reruns
   once per (noise, temperature) cell rather than once total. This is a known, deliberate
   correctness-first tradeoff, not an oversight: real necklace rows have 5 temperatures x 1
-  noise = 5 redundant structure reloads per row, cheap relative to the AR sampling compute
-  itself. Refactoring to load structures once and reuse across cells is a real, tracked
-  follow-up optimization if profiling ever shows this reload cost matters at production scale --
-  not applied here to keep this integration's first version small and easy to verify correct.
+  noise = 5 redundant structure reloads (real PDB I/O + padding + chain filtering) per row --
+  cheap relative to the AR sampling compute itself (an independent PR audit confirmed
+  `sample_states_fused`'s `@eqx.filter_jit` sits on the OUTER function specifically so the
+  compiled AR-sampling executable is traced ONCE and reused across all 5 cells' worth of
+  structure-reload-then-sample calls, not retraced per cell -- only the cheap host-side
+  reload repeats, not the expensive JIT compile). Refactoring to load structures once and
+  reuse across cells is a real, tracked follow-up optimization if profiling ever shows this
+  reload cost matters at production scale -- not applied here to keep this integration's
+  first version small and easy to verify correct.
 
   Parameters
   ----------
@@ -432,7 +452,26 @@ def sample_multistate_poe_campaign_row(spec: SamplingSpecification) -> dict[str,
   canonical_structure_ids = _canonical_structure_ids_for_spec(spec)
   total_num_samples = resolve_target_samples(spec, grid_lineage=grid_lineage)
   chunk_size = resolve_chunk_size(spec, total_num_samples, grid_lineage)
-  base_key = _base_sampling_key(spec, grid_lineage=grid_lineage)
+  if total_num_samples != chunk_size:
+    msg = (
+      f"sample_multistate_poe_campaign_row assumes one manifest row produces exactly one "
+      f"chunk (total_num_samples == chunk_size); got total_num_samples={total_num_samples}, "
+      f"chunk_size={chunk_size}. Every real necklace manifest row sets samples_chunk_size == "
+      "sample_count per row (build_necklace_p2_manifest.py's chunking splits a bead across "
+      "MULTIPLE rows, not multiple chunks within one row) -- this row's manifest builder "
+      "violated that convention. Multi-chunk-per-row accumulation is not implemented here; "
+      "fix the manifest builder rather than silently truncating output to chunk_size."
+    )
+    raise ValueError(msg)
+
+  # CRITICAL: fold sample_start into the base key -- _base_sampling_key's own hash does not
+  # incorporate chunk_id/sample_start (it's keyed off job_id + strategy/conditioning fields
+  # only), so without this, two manifest rows sharing one job_id but different chunk_id/
+  # sample_start (exactly how a >samples_chunk_size bead gets split into multiple rows) would
+  # derive the SAME base key and produce byte-identical duplicated samples. See this
+  # function's docstring "CRITICAL" note and the two-rows-same-job regression test.
+  sample_start = resolve_sample_start(grid_lineage)
+  base_key = jax.random.fold_in(_base_sampling_key(spec, grid_lineage=grid_lineage), sample_start)
 
   temperature_val = spec.run_spec.sampling.temperature
   temperatures = (

--- a/tests/host/test_multistate_poe_campaign_integration.py
+++ b/tests/host/test_multistate_poe_campaign_integration.py
@@ -17,6 +17,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import zarr
 
 from aminx.host.campaign import MANIFEST_SCHEMA_VERSION, run_manifest_row
@@ -192,3 +193,121 @@ class TestMultistatePoeCampaignRowRouting:
     assert result["status"] == "completed"
     mock_sample.assert_called_once()
     mock_poe_row.assert_not_called()
+
+
+class TestGridLineageChunking:
+  """Regression coverage for the critical finding from the 2026-07-14 PR audit: two manifest
+  rows sharing one job_id but different chunk_id/sample_start (exactly how a real necklace bead
+  whose design count exceeds samples_chunk_size gets split into multiple rows,
+  build_necklace_p2_manifest.py) must NOT derive the same base key and produce duplicated
+  samples. Previously, _base_sampling_key's own hash never incorporated chunk_id/sample_start,
+  so this scenario silently duplicated output -- caught by an independent audit before merge,
+  not previously exercised by any test (grid_mode was never set in earlier tests).
+  """
+
+  def _grid_row_manifest(self, tmp_path, inputs, state_position_map, *, job_id, chunk_id,
+                          sample_start, sample_count, row_hash):
+    output_path = tmp_path / f"{row_hash}.h5"
+    manifest_path = tmp_path / f"{row_hash}_manifest.json"
+    manifest = {
+      "schema_version": MANIFEST_SCHEMA_VERSION,
+      "rows": [
+        {
+          "manifest_row_hash": row_hash,
+          "job_id": job_id,
+          "job_index": 0,
+          "sampling_spec": {
+            "inputs": inputs,
+            "batch_size": len(inputs),
+            "multi_state_strategy": "product",
+            "state_position_map": state_position_map,
+            "return_logits": True,
+            "grid_mode": True,
+            "job_id": job_id,
+            "chunk_id": chunk_id,
+            "sample_start": sample_start,
+            "sample_count": sample_count,
+            "samples_chunk_size": sample_count,
+            "output_h5_path": str(output_path),
+          },
+        },
+      ],
+    }
+    manifest_path.write_text(json.dumps(manifest))
+    return manifest_path, output_path
+
+  def test_two_chunks_of_same_job_produce_distinct_samples(self, tmp_path):
+    """The critical regression: chunk_id=0/sample_start=0 vs chunk_id=1/sample_start=2 of the
+    SAME job_id must produce genuinely different sequences, not a byte-identical duplicate.
+    """
+    inputs = [f"{REPO_TESTS_DATA}/1ubq.pdb", f"{REPO_TESTS_DATA}/1mbn.pdb"]
+    synthetic_model = _synthetic_model()
+    state_position_map = _real_state_position_map(inputs, synthetic_model)
+    job_id = "necklace_p2_shared_job"
+
+    manifest_a, output_a = self._grid_row_manifest(
+      tmp_path, inputs, state_position_map,
+      job_id=job_id, chunk_id=0, sample_start=0, sample_count=2, row_hash="chunk_a",
+    )
+    manifest_b, output_b = self._grid_row_manifest(
+      tmp_path, inputs, state_position_map,
+      job_id=job_id, chunk_id=1, sample_start=2, sample_count=2, row_hash="chunk_b",
+    )
+
+    with patch("aminx.host.prep.load_model", return_value=synthetic_model):
+      result_a = run_manifest_row(manifest_path=str(manifest_a), row_hash="chunk_a")
+      result_b = run_manifest_row(manifest_path=str(manifest_b), row_hash="chunk_b")
+
+    assert result_a["status"] == "completed"
+    assert result_b["status"] == "completed"
+
+    sequences_a = np.asarray(zarr.open_group(str(output_a), mode="r")["poe_fused"]["sequences"])
+    sequences_b = np.asarray(zarr.open_group(str(output_b), mode="r")["poe_fused"]["sequences"])
+
+    assert not np.array_equal(sequences_a, sequences_b), (
+      "two chunks of the same job (same job_id, different chunk_id/sample_start) produced "
+      "byte-identical sequences -- the sample_start fold-in regression is back"
+    )
+
+  def test_chunk_size_mismatch_raises_instead_of_silently_truncating(self, tmp_path):
+    """If a manifest row's sample_count != samples_chunk_size (a manifest-builder bug --
+    every real necklace row sets these equal), this must raise a clear error rather than
+    silently writing only chunk_size samples while claiming num_samples=chunk_size in attrs.
+    """
+    inputs = [f"{REPO_TESTS_DATA}/1ubq.pdb", f"{REPO_TESTS_DATA}/1mbn.pdb"]
+    synthetic_model = _synthetic_model()
+    state_position_map = _real_state_position_map(inputs, synthetic_model)
+
+    output_path = tmp_path / "mismatch.h5"
+    manifest_path = tmp_path / "mismatch_manifest.json"
+    manifest = {
+      "schema_version": MANIFEST_SCHEMA_VERSION,
+      "rows": [
+        {
+          "manifest_row_hash": "mismatch_row",
+          "job_id": "job_mismatch",
+          "job_index": 0,
+          "sampling_spec": {
+            "inputs": inputs,
+            "batch_size": len(inputs),
+            "multi_state_strategy": "product",
+            "state_position_map": state_position_map,
+            "return_logits": True,
+            "grid_mode": True,
+            "job_id": "job_mismatch",
+            "chunk_id": 0,
+            "sample_start": 0,
+            "sample_count": 4,
+            "samples_chunk_size": 2,  # deliberately mismatched
+            "output_h5_path": str(output_path),
+          },
+        },
+      ],
+    }
+    manifest_path.write_text(json.dumps(manifest))
+
+    with (
+      patch("aminx.host.prep.load_model", return_value=synthetic_model),
+      pytest.raises(Exception, match="assumes one manifest row produces exactly one chunk"),
+    ):
+      run_manifest_row(manifest_path=str(manifest_path), row_hash="mismatch_row")

--- a/tests/host/test_multistate_poe_campaign_integration.py
+++ b/tests/host/test_multistate_poe_campaign_integration.py
@@ -1,0 +1,194 @@
+"""Real end-to-end test of the multistate PoE campaign-pipeline wiring.
+
+Regression coverage for the 2026-07-14 integration (tev_design task
+260709_multistate-fusion-strategy-comparison, Phase 3): host/campaign.py::run_manifest_row must
+route genuine multi-state PoE rows (len(inputs) > 1) to
+aminx.sampling.multistate_poe.sample_multistate_poe_campaign_row instead of
+host/runner.py::sample(), while single-structure ("spike-in") rows keep using sample() unchanged.
+See .praxia/docs/decisions/260713_no-real-multistate-sampling-path-exists.md.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import zarr
+
+from aminx.host.campaign import MANIFEST_SCHEMA_VERSION, run_manifest_row
+from aminx.host.prep import prep_protein_stream_and_model
+from aminx.model import Aminx
+from aminx.run.specs import SamplingSpecification
+from aminx.utils.align import build_state_position_map
+
+REPO_TESTS_DATA = __file__.rsplit("/tests/", 1)[0] + "/tests/data"
+
+
+def _synthetic_model() -> Aminx:
+  model = Aminx(
+    node_features=32,
+    edge_features=32,
+    hidden_features=32,
+    num_encoder_layers=1,
+    num_decoder_layers=1,
+    k_neighbors=8,
+    dropout_rate=0.0,
+    key=jax.random.PRNGKey(11),
+  )
+  return eqx.tree_inference(model, value=True)
+
+
+def _real_state_position_map(inputs: list[str], synthetic_model: Aminx) -> list[list[int]]:
+  """Mirrors tev_design's compute_state_position_map: real alignment, then -1-padded to L."""
+  spec = SamplingSpecification(inputs=inputs, batch_size=len(inputs), return_logits=True)
+  with patch("aminx.host.prep.load_model", return_value=synthetic_model):
+    protein_iterator, _ = prep_protein_stream_and_model(spec)
+    batched_ensemble = list(protein_iterator)[0]
+
+  seq_len = batched_ensemble.coordinates.shape[1]
+  n_states = batched_ensemble.coordinates.shape[0]
+  native_lens = [int(m.sum()) for m in batched_ensemble.mask]
+  max_native_len = max(native_lens)
+  native_seqs = jnp.full((n_states, max_native_len), -1, dtype=jnp.int32)
+  for s in range(n_states):
+    native_seqs = native_seqs.at[s, : native_lens[s]].set(
+      batched_ensemble.aatype[s, : native_lens[s]].astype(jnp.int32),
+    )
+  aligned = build_state_position_map(native_seqs, reference_state_index=0)
+  padded = jnp.full((n_states, seq_len), -1, dtype=jnp.int32)
+  padded = padded.at[:, :max_native_len].set(aligned)
+  return np.asarray(padded).tolist()
+
+
+class TestMultistatePoeCampaignRowRouting:
+  """run_manifest_row must route multi-state rows to the new function, spike-in rows to sample()."""
+
+  def test_multistate_poe_row_writes_real_fused_output(self, tmp_path):
+    """Real end-to-end: a genuine multi-state PoE manifest row, run through
+    run_manifest_row exactly as `aminx campaign run` would invoke it, produces real
+    fused output at the row's output_h5_path -- not a per-structure independent result.
+    Only the model weights are mocked; manifest loading, locking, done-marker writing,
+    structure parsing, bundle construction, fusion, sampling, and Zarr writing are all
+    real, unmocked code paths.
+    """
+    inputs = [f"{REPO_TESTS_DATA}/1ubq.pdb", f"{REPO_TESTS_DATA}/1mbn.pdb"]
+    synthetic_model = _synthetic_model()
+    state_position_map = _real_state_position_map(inputs, synthetic_model)
+
+    output_path = tmp_path / "poe_row.h5"
+    manifest_path = tmp_path / "manifest.json"
+    row_hash = "test_multistate_poe_row"
+    manifest = {
+      "schema_version": MANIFEST_SCHEMA_VERSION,
+      "rows": [
+        {
+          "manifest_row_hash": row_hash,
+          "job_id": "job0",
+          "job_index": 0,
+          "sampling_spec": {
+            "inputs": inputs,
+            "batch_size": len(inputs),
+            "multi_state_strategy": "product",
+            "state_position_map": state_position_map,
+            "return_logits": True,
+            "num_samples": 2,
+            "output_h5_path": str(output_path),
+          },
+        },
+      ],
+    }
+    manifest_path.write_text(json.dumps(manifest))
+
+    with patch("aminx.host.prep.load_model", return_value=synthetic_model):
+      result = run_manifest_row(
+        manifest_path=str(manifest_path),
+        row_hash=row_hash,
+        lock_backend="local_fs",
+      )
+
+    assert result["status"] == "completed"
+    assert output_path.exists()
+    assert not any(tmp_path.glob("*.partial.*"))
+
+    root = zarr.open_group(str(output_path), mode="r")
+    assert "poe_fused" in root
+    assert "structure_0" not in root, (
+      "a genuine PoE row must not produce per-structure groups -- that's exactly the "
+      "broken behavior this integration replaces"
+    )
+    fused = root["poe_fused"]
+    sequences = np.asarray(fused["sequences"])
+    logits = np.asarray(fused["logits"])
+    assert sequences.shape[0] == 2  # num_samples
+    assert sequences.shape[-1] == logits.shape[-2]  # L matches
+    assert logits.shape[-1] == 21
+    assert bool(np.all(np.isfinite(logits)))
+    assert fused.attrs["structure_id"] == "poe_fused"
+    assert fused.attrs["fused_structure_ids"] == ["1ubq", "1mbn"] or len(
+      fused.attrs["fused_structure_ids"],
+    ) == 2
+
+    # Retry short-circuits via the done marker, without re-running the (expensive) sampling.
+    with patch(
+      "aminx.sampling.multistate_poe.sample_multistate_poe_bead",
+    ) as mock_sample_bead:
+      result2 = run_manifest_row(
+        manifest_path=str(manifest_path),
+        row_hash=row_hash,
+        lock_backend="local_fs",
+      )
+    assert result2["status"] == "already_done"
+    mock_sample_bead.assert_not_called()
+
+  def test_spike_in_row_uses_sample_not_the_poe_wrapper(self, tmp_path):
+    """A single-structure ("spike-in") row -- len(inputs) == 1 -- must keep going through
+    sample()/_sample_batch unchanged; sample_multistate_poe_campaign_row must never be
+    called for it. Uses a fake sample() (mirroring
+    TestRunManifestRowZarrLifecycle.test_happy_path_creates_zarr_store_and_marker's existing
+    pattern) since a real single-structure sample() call is already covered elsewhere and
+    is not what this test is checking.
+    """
+    output_path = tmp_path / "spikein_row.h5"
+    manifest_path = tmp_path / "manifest.json"
+    row_hash = "test_spikein_row"
+    manifest = {
+      "schema_version": MANIFEST_SCHEMA_VERSION,
+      "rows": [
+        {
+          "manifest_row_hash": row_hash,
+          "job_id": "job0",
+          "job_index": 0,
+          "sampling_spec": {
+            "inputs": [f"{REPO_TESTS_DATA}/1ubq.pdb"],
+            "output_h5_path": str(output_path),
+          },
+        },
+      ],
+    }
+    manifest_path.write_text(json.dumps(manifest))
+
+    def _fake_sample(spec):
+      root = zarr.open_group(str(spec.output_h5_path), mode="a")
+      arr = root.create_array(name="sequences", shape=(1,), dtype="int32")
+      arr[...] = np.array([3], dtype=np.int32)
+      return {"status": "completed"}
+
+    with (
+      patch("aminx.host.campaign.sample", side_effect=_fake_sample) as mock_sample,
+      patch(
+        "aminx.host.campaign.sample_multistate_poe_campaign_row",
+      ) as mock_poe_row,
+    ):
+      result = run_manifest_row(
+        manifest_path=str(manifest_path),
+        row_hash=row_hash,
+        lock_backend="local_fs",
+      )
+
+    assert result["status"] == "completed"
+    mock_sample.assert_called_once()
+    mock_poe_row.assert_not_called()


### PR DESCRIPTION
## Summary
- Closes the remaining gap from PR #101: `aminx.sampling.multistate_poe` existed as a standalone callable but nothing routed real campaign manifest rows to it, so PoE rows would still raise `ValueError` (the PR #100 fail-loud fix) when run through `aminx campaign run`.
- `host/campaign.py::run_manifest_row` now detects genuine multi-state PoE rows (`len(sampling_spec.inputs) > 1`) and calls the new `sample_multistate_poe_campaign_row` instead of `sample()`. Single-structure spike-in rows are untouched.
- New `sample_multistate_poe_campaign_row`: resolves the real campaign chunk/sample-count/lineage axes via the same helpers `_sample_streaming` uses, derives its base PRNG key via the same `_base_sampling_key` convention, loops over the real temperature/backbone_noise grid, and writes output via `xtrax.run.ZarrStagingSink`/`SinkSpec` — the same Sink primitive `_sample_streaming` uses — so `run_manifest_row`'s surrounding locking/done-marker/retry infrastructure works unchanged. Writes ONE `"poe_fused"` Zarr group (not per-structure groups) since states are genuinely fused.
- `sample_states_fused` now dispatches its `n_samples` axis via the established `_plan_axis_strategy` + `make_axis_dispatch_via_xtrax` idiom (reusing the existing `N_SAMPLES` `AxisSpec`), matching `N_CANDIDATES`/`N_REPLICATES` in `conditional_logits.py`, instead of a bare `jax.vmap` — addresses a real architecture concern about leveraging xtrax's composable dispatch machinery consistently.
- Verified `prep_protein_stream_and_model` is the current, accepted host-loading convention (not legacy/in-migration) via `.praxia/docs/specs/260706_epic1541-p4-runner-hostsinks-scoping.md` (CONVERGED) — xtrax's `InputResolver`/`RuntimeBundle` protocol is real but unbuilt backlog (#1910), explicitly scoped as unrelated to the sampling runner.

## Test plan
- [x] 2 new real end-to-end tests (`tests/host/test_multistate_poe_campaign_integration.py`) — a genuine multi-state PoE manifest row run through `run_manifest_row` exactly as `aminx campaign run` would invoke it, confirming real fused output and done-marker short-circuit on retry; a spike-in row confirming it still routes to `sample()`, never the new function
- [x] Full `multistate_poe` + campaign-manifest test suites: 11 + 47 passed
- [ ] Full aminx suite (running)
- [ ] Independent adversarial audit (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)