### PR TITLE
chore: bump version 0.1.0a14 -> 0.1.0a15 (multistate PoE fusion, #100/#101/#102)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a14"
+version = "0.1.0a15"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
## Summary
Version bump reflecting three merged PRs since a14: #100 (corruption-symptom fix), #101 (multistate PoE fusion MVP), #102 (campaign pipeline wiring, incl. a critical sample-duplication fix). Follows this repo's established convention of bumping the version with each meaningful merge. No code changes beyond `pyproject.toml`'s `version` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)