### PR TITLE
fix(run): derive model_family from checkpoint_id when unset

### DIFF
--- a/src/aminx/cli.py
+++ b/src/aminx/cli.py
@@ -407,7 +407,7 @@ class _RunBase:
   topology: str | None
   model_weights: str
   model_version: str
-  model_family: str
+  model_family: str | None
   checkpoint_id: str | None
   model_local_path: Path | None
   checkpoint_registry_path: Path | None
@@ -452,9 +452,13 @@ def _run_base(
   model_weights: Annotated[str, _OPT(help="Model weights name")] = "original",
   model_version: Annotated[str, _OPT(help="Model version")] = "v_48_020",
   model_family: Annotated[
-    str,
-    _OPT(help="Model family: proteinmpnn or ligandmpnn"),
-  ] = "proteinmpnn",
+    str | None,
+    _OPT(
+      help="Model family: proteinmpnn or ligandmpnn. Leave unset to auto-derive from "
+      "checkpoint_id (RunSpecification.__post_init__); an explicit value here is always "
+      "respected even if it disagrees with checkpoint_id.",
+    ),
+  ] = None,
   checkpoint_id: Annotated[str | None, _OPT(help="Checkpoint identifier")] = None,
   model_local_path: Annotated[Path | None, _OPT(help="Local model checkpoint path")] = None,
   checkpoint_registry_path: Annotated[Path | None, _OPT(help="Checkpoint registry path")] = None,
@@ -1020,9 +1024,13 @@ def _spec_base(
   model_weights: Annotated[str, _OPT(help="Model weights name")] = "original",
   model_version: Annotated[str, _OPT(help="Model version")] = "v_48_020",
   model_family: Annotated[
-    str,
-    _OPT(help="Model family: proteinmpnn or ligandmpnn"),
-  ] = "proteinmpnn",
+    str | None,
+    _OPT(
+      help="Model family: proteinmpnn or ligandmpnn. Leave unset to auto-derive from "
+      "checkpoint_id (RunSpecification.__post_init__); an explicit value here is always "
+      "respected even if it disagrees with checkpoint_id.",
+    ),
+  ] = None,
   checkpoint_id: Annotated[str | None, _OPT(help="Checkpoint identifier")] = None,
   model_local_path: Annotated[Path | None, _OPT(help="Local model checkpoint path")] = None,
   checkpoint_registry_path: Annotated[Path | None, _OPT(help="Checkpoint registry path")] = None,

--- a/src/aminx/run/specs.py
+++ b/src/aminx/run/specs.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TextIO, cast
 
 from aminx.io.proxide_fetch import InputResolutionError
+from aminx.io.weights import get_topology_for_checkpoint
 from aminx.model.versions import MODEL_VERSION, MODEL_WEIGHTS
 
 from .spec import RunSpec, build_run_spec
@@ -224,7 +225,16 @@ class RunSpecification:
   topology: str | Path | None = None
   model_weights: ModelWeights = "original"
   model_version: ModelVersion = "v_48_020"
-  model_family: Literal["proteinmpnn", "ligandmpnn"] = "proteinmpnn"
+  # None means "not explicitly set by the caller" -- __post_init__ resolves this to a real
+  # Literal value (derived from checkpoint_id when possible, else "proteinmpnn") before
+  # __init__ returns, so every RunSpecification/SamplingSpecification instance always has a
+  # concrete model_family by the time any caller reads it. An explicit "proteinmpnn"/
+  # "ligandmpnn" from the caller is never overridden -- only the None (unset) case gets
+  # auto-derived. See __post_init__ for why this matters: model_family gates real ligand/
+  # sidechain context injection (host/_sampling_helper.py::_prepare_ligand_context)
+  # independent of checkpoint_id, and a caller who forgot to set it got a silent no-op
+  # (found live 2026-07-14).
+  model_family: Literal["proteinmpnn", "ligandmpnn"] | None = None
   checkpoint_id: str | None = None
   model_local_path: str | Path | None = None
   checkpoint_registry_path: str | Path | None = None
@@ -447,6 +457,51 @@ class RunSpecification:
         f"Got pass_mode='{self.pass_mode}'."
       )
       raise ValueError(msg)
+
+    # model_family gates real ligand-atom AND sidechain-atom injection
+    # (host/_sampling_helper.py::_prepare_ligand_context), completely independent of
+    # checkpoint_id -- the two fields must stay in sync but nothing enforced that, so a
+    # caller who set checkpoint_id="ligandmpnn_v_32_020_25" but never touched model_family
+    # got a LigandMPNN checkpoint's weights loaded correctly (get_topology_for_checkpoint
+    # already derives architecture from checkpoint_id for weight selection) while real
+    # ligand/sidechain context was silently never passed to it -- a clean, no-crash no-op
+    # (found live 2026-07-14, tev_design necklace P2 campaign: every ligand- and
+    # sidechain-conditioned row sampled through `aminx campaign plan/run` ran with zero real
+    # ligand/sidechain atoms).
+    #
+    # model_family defaults to None (not a Literal) specifically so this resolution can tell
+    # "caller never set it" apart from "caller explicitly set it to 'proteinmpnn'" -- an
+    # earlier version of this fix used the string default "proteinmpnn" as the trigger
+    # condition and, caught by its own test, silently overrode a genuinely explicit
+    # model_family="proteinmpnn" the same as an unset one. Only the None (truly unset) case
+    # is auto-derived here; an explicit value is never touched.
+    derived_topology = (
+      get_topology_for_checkpoint(self.checkpoint_id) if self.checkpoint_id is not None else None
+    )
+    is_ligand_checkpoint = derived_topology is not None and derived_topology["model_type"] in (
+      "ligand",
+      "packer",
+    )
+    if self.model_family is None:
+      resolved = "ligandmpnn" if is_ligand_checkpoint else "proteinmpnn"
+      if is_ligand_checkpoint:
+        logger.info(
+          "model_family not set; derived 'ligandmpnn' from checkpoint_id=%r.",
+          self.checkpoint_id,
+        )
+      object.__setattr__(self, "model_family", resolved)
+    elif self.model_family == "proteinmpnn" and is_ligand_checkpoint:
+      # Explicit value respected, but flagged loudly -- this combination is either a
+      # deliberate ablation (LigandMPNN weights, intentionally no real ligand/sidechain
+      # context) or a real caller mistake; either way it should never be silent.
+      logger.warning(
+        "model_family explicitly set to 'proteinmpnn' but checkpoint_id=%r indicates a "
+        "LigandMPNN-family checkpoint -- real ligand/sidechain context will NOT reach the "
+        "model. If this is intentional (an ablation), ignore this warning; if not, remove "
+        "the explicit model_family='proteinmpnn' and let it auto-derive.",
+        self.checkpoint_id,
+      )
+
     self._sync_run_spec()
 
 

--- a/src/aminx/run/specs.py
+++ b/src/aminx/run/specs.py
@@ -501,6 +501,23 @@ class RunSpecification:
         "the explicit model_family='proteinmpnn' and let it auto-derive.",
         self.checkpoint_id,
       )
+    elif (
+      self.model_family == "ligandmpnn"
+      and derived_topology is not None
+      and not is_ligand_checkpoint
+    ):
+      # Symmetric case: explicit "ligandmpnn" but checkpoint_id clearly indicates a
+      # non-ligand (protein/membrane) checkpoint -- flagged for the same reason as the
+      # branch above (equally suspicious caller/checkpoint disagreement), even though
+      # get_topology_for_checkpoint's real architecture selection (used by load_model for
+      # weight loading, independent of this field) will likely surface this as a loud
+      # shape/kwarg mismatch downstream rather than a silent no-op.
+      logger.warning(
+        "model_family explicitly set to 'ligandmpnn' but checkpoint_id=%r does not indicate "
+        "a LigandMPNN-family checkpoint -- this combination is unusual; verify checkpoint_id "
+        "is correct.",
+        self.checkpoint_id,
+      )
 
     self._sync_run_spec()
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -275,3 +275,142 @@ class TestPortableRoundtrip:
         assert result.exit_code == 0, result.output
         parsed = json.loads(result.output)
         assert isinstance(parsed, dict)
+
+
+class TestModelFamilyCliDefaultAutoDerives:
+  """`aminx run`/`aminx spec` share a `--model-family` Typer option that used to hardcode
+  the literal default `"proteinmpnn"` -- bypassing RunSpecification.__post_init__'s
+  checkpoint_id-derived auto-correction entirely for these CLI entry points (a caller
+  running `aminx run sample --checkpoint-id ligandmpnn_v_32_020_25` without also passing
+  `--model-family ligandmpnn` got the exact same silent no-op the fix elsewhere in this PR
+  closes). Fixed by defaulting the CLI option to None, matching the dataclass field's own
+  default, so the callback's None flows through _base_spec_kwargs into RunSpecification
+  unchanged and gets derived the same way as any other caller.
+  """
+
+  def test_run_base_model_family_option_defaults_to_none(self):
+    """Typer option default must be None, not the string "proteinmpnn" -- a hardcoded
+    string default here silently bypasses the checkpoint_id-derived auto-correction for
+    every `aminx run` invocation, regardless of what RunSpecification.__post_init__ does.
+    """
+    import inspect
+
+    from aminx.cli import _run_base
+
+    sig = inspect.signature(_run_base)
+    assert sig.parameters["model_family"].default is None
+
+  def test_spec_base_model_family_option_defaults_to_none(self):
+    """Same check for `aminx spec`'s callback (a separate Typer app/callback sharing the
+    same option shape, not automatically covered by the `run` callback's own fix).
+    """
+    import inspect
+
+    from aminx.cli import _spec_base
+
+    sig = inspect.signature(_spec_base)
+    assert sig.parameters["model_family"].default is None
+
+  def test_base_spec_kwargs_forwards_none_model_family_unchanged(self):
+    """_base_spec_kwargs must forward model_family=None as-is (not coerce it back to a
+    string) so RunSpecification.__post_init__ still sees the real "unset" sentinel.
+    """
+    from aminx.cli import _RunBase, _base_spec_kwargs
+
+    base = _RunBase(
+      topology=None,
+      model_weights="original",
+      model_version="v_48_020",
+      model_family=None,
+      checkpoint_id="ligandmpnn_v_32_020_25",
+      model_local_path=None,
+      checkpoint_registry_path=None,
+      ligand_mpnn_use_side_chain_context=None,
+      batch_size=None,
+      backbone_noise="0.0",
+      backbone_noise_mode=None,
+      estat_noise=None,
+      estat_noise_mode=None,
+      vdw_noise=None,
+      vdw_noise_mode=None,
+      use_electrostatics=False,
+      use_vdw=False,
+      random_seed=42,
+      chain_id=None,
+      model=None,
+      altloc="first",
+      cache_path=None,
+      output_dir=None,
+      max_buffer_size=None,
+      overwrite_cache=False,
+      max_length=None,
+      truncation_strategy="none",
+      host_resource_allocation_strategy="auto",
+      ram_budget_mb=None,
+      max_workers=None,
+      n_devices=None,
+      use_preprocessed=False,
+      preprocessed_index_path=None,
+      split="train",
+      tied_position=[],
+      pass_mode="intra",
+      multi_state_temperature=1.0,
+      input_type="auto",
+      input_cache_dir=None,
+    )
+    kwargs = _base_spec_kwargs(base)
+    assert kwargs["model_family"] is None
+
+  def test_run_base_with_ligand_checkpoint_and_no_model_family_derives_correctly(self):
+    """End-to-end: constructing a real SamplingSpecification from _base_spec_kwargs'
+    output (the exact dict `aminx run`'s subcommands pass into spec constructors) with a
+    LigandMPNN checkpoint_id and no --model-family derives 'ligandmpnn', matching the
+    campaign/manifest pipeline's already-fixed behavior.
+    """
+    from aminx.cli import _RunBase, _base_spec_kwargs
+    from aminx.run.specs import SamplingSpecification
+
+    base = _RunBase(
+      topology=None,
+      model_weights="original",
+      model_version="v_48_020",
+      model_family=None,
+      checkpoint_id="ligandmpnn_v_32_020_25",
+      model_local_path=None,
+      checkpoint_registry_path=None,
+      ligand_mpnn_use_side_chain_context=None,
+      batch_size=None,
+      backbone_noise="0.0",
+      backbone_noise_mode=None,
+      estat_noise=None,
+      estat_noise_mode=None,
+      vdw_noise=None,
+      vdw_noise_mode=None,
+      use_electrostatics=False,
+      use_vdw=False,
+      random_seed=42,
+      chain_id=None,
+      model=None,
+      altloc="first",
+      cache_path=None,
+      output_dir=None,
+      max_buffer_size=None,
+      overwrite_cache=False,
+      max_length=None,
+      truncation_strategy="none",
+      host_resource_allocation_strategy="auto",
+      ram_budget_mb=None,
+      max_workers=None,
+      n_devices=None,
+      use_preprocessed=False,
+      preprocessed_index_path=None,
+      split="train",
+      tied_position=[],
+      pass_mode="intra",
+      multi_state_temperature=1.0,
+      input_type="auto",
+      input_cache_dir=None,
+    )
+    kwargs = _base_spec_kwargs(base)
+    spec = SamplingSpecification(inputs="test.pdb", **kwargs)
+    assert spec.model_family == "ligandmpnn"

--- a/tests/host/test_sampling_helper.py
+++ b/tests/host/test_sampling_helper.py
@@ -1,6 +1,8 @@
-"""Tests for _sampling_helper._prepare_fixed_controls function.
+"""Tests for _sampling_helper._prepare_fixed_controls and _prepare_ligand_context functions.
 
-Focus: Fixed mask application correctness, no double-application bug.
+Focus: Fixed mask application correctness, no double-application bug; and that
+model_family (checkpoint_id-derived per run/specs.py::RunSpecification.__post_init__) is
+what actually gates real ligand/sidechain-atom injection.
 """
 
 from __future__ import annotations
@@ -9,7 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from aminx.host._sampling_helper import _prepare_fixed_controls
+from aminx.host._sampling_helper import _prepare_fixed_controls, _prepare_ligand_context
 from aminx.run.specs import SamplingSpecification
 from aminx.utils.data_structures import Protein
 
@@ -171,3 +173,98 @@ class TestPrepareFixedControlsFixedMask:
 
     # Verify that all values are <= 1.0 (sanity check for double-application)
     assert np.all(np.asarray(fixed_mask_out) <= 1.0), "Mask values exceed 1.0 (possible double-application)"
+
+
+class TestPrepareLigandContextModelFamilyGate:
+  """_prepare_ligand_context gates BOTH real ligand-atom (Y/Y_t/Y_m) and real
+  sidechain-atom (atom_37/atom_37_mask) injection on a single early-return keyed off
+  spec.model_family == "ligandmpnn" -- not checkpoint_id, not sidechain_conditioning
+  directly. A caller who set checkpoint_id to a LigandMPNN checkpoint but never touched
+  model_family got that checkpoint's weights loaded correctly (get_topology_for_checkpoint
+  already derives architecture from checkpoint_id for weight selection) while real
+  ligand/sidechain context was silently never passed to it -- found live 2026-07-14 in
+  tev_design's necklace P2 campaign (three of six model beads sampled with zero real
+  ligand/sidechain atoms, no crash, no error).
+
+  These tests exercise the REAL construction path a production caller uses -- kwargs into
+  SamplingSpecification's __init__, letting __post_init__ derive model_family from
+  checkpoint_id -- rather than a hand-constructed spec with model_family already set
+  correctly (which is what every OTHER test touching _prepare_ligand_context does, and
+  exactly the gap that let this bug ship: the unit was well-tested in isolation, the wiring
+  from a realistic construction path was not).
+  """
+
+  def test_sidechain_atom_context_reaches_model_when_model_family_unset(self):
+    """The exact regression: checkpoint_id set, model_family left unset,
+    sidechain_conditioning=True -- atom_37/atom_37_mask must be real arrays, not None.
+    """
+    batch_size = 1
+    seq_len = 10
+    protein = _make_fake_protein(batch_size=batch_size, seq_len=seq_len)
+
+    spec = SamplingSpecification(
+      inputs=[],
+      checkpoint_id="ligandmpnn_v_32_020_25",
+      sidechain_conditioning=True,
+    )
+    assert spec.model_family == "ligandmpnn", (
+      "precondition: model_family must have been auto-derived from checkpoint_id"
+    )
+
+    ligand_context = _prepare_ligand_context(
+      spec, batched_ensemble=protein, batch_size=batch_size, seq_len=seq_len,
+    )
+
+    assert ligand_context["atom_37"] is not None, (
+      "sidechain_conditioning=True with a LigandMPNN checkpoint must produce real "
+      "atom_37 coordinates -- got None, meaning the model_family gate silently closed."
+    )
+    assert ligand_context["atom_37_mask"] is not None
+    np.testing.assert_array_equal(
+      np.asarray(ligand_context["atom_37"]), np.asarray(protein.coordinates),
+    )
+
+  def test_sidechain_atom_context_is_none_without_sidechain_conditioning(self):
+    """Sanity check on the OTHER half of the branch: even with model_family correctly
+    'ligandmpnn', atom_37 stays None when sidechain_conditioning=False (default) -- this
+    confirms the test above is exercising the real gate, not a fixture that always returns
+    non-None regardless of configuration.
+    """
+    batch_size = 1
+    seq_len = 10
+    protein = _make_fake_protein(batch_size=batch_size, seq_len=seq_len)
+
+    spec = SamplingSpecification(
+      inputs=[],
+      checkpoint_id="ligandmpnn_v_32_020_25",
+      sidechain_conditioning=False,
+    )
+    assert spec.model_family == "ligandmpnn"
+
+    ligand_context = _prepare_ligand_context(
+      spec, batched_ensemble=protein, batch_size=batch_size, seq_len=seq_len,
+    )
+    assert ligand_context["atom_37"] is None
+    assert ligand_context["atom_37_mask"] is None
+
+  def test_all_context_is_none_for_proteinmpnn_checkpoint(self):
+    """Baseline: a genuinely proteinmpnn checkpoint (no ligand family at all) correctly
+    gets None ligand/sidechain context regardless of sidechain_conditioning -- confirms the
+    fix didn't flip this into an always-real-context bug in the other direction.
+    """
+    batch_size = 1
+    seq_len = 10
+    protein = _make_fake_protein(batch_size=batch_size, seq_len=seq_len)
+
+    spec = SamplingSpecification(
+      inputs=[],
+      checkpoint_id="proteinmpnn_v_48_020",
+      sidechain_conditioning=True,
+    )
+    assert spec.model_family == "proteinmpnn"
+
+    ligand_context = _prepare_ligand_context(
+      spec, batched_ensemble=protein, batch_size=batch_size, seq_len=seq_len,
+    )
+    assert ligand_context["atom_37"] is None
+    assert ligand_context["Y"] is None

--- a/tests/run/test_specs.py
+++ b/tests/run/test_specs.py
@@ -336,6 +336,25 @@ class TestModelFamilyCheckpointDerivation:
         )
         assert spec.model_family == "ligandmpnn"
 
+    def test_explicit_model_family_ligandmpnn_with_protein_checkpoint_warns(
+        self, minimal_run_spec_kwargs: dict, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The symmetric case of test_explicit_model_family_never_silently_overridden:
+        explicit model_family='ligandmpnn' with a checkpoint_id that does NOT indicate a
+        LigandMPNN-family checkpoint is an equally suspicious disagreement and must also
+        warn (an earlier version of this fix only warned in one direction).
+        """
+        with caplog.at_level("WARNING"):
+            spec = RunSpecification(
+                **minimal_run_spec_kwargs,
+                checkpoint_id="proteinmpnn_v_48_020",
+                model_family="ligandmpnn",
+            )
+        assert spec.model_family == "ligandmpnn", "explicit value must still be respected"
+        assert any(
+            "explicitly set to 'ligandmpnn'" in record.message for record in caplog.records
+        )
+
 
 # ============================================================================
 # ScoringSpecification Tests

--- a/tests/run/test_specs.py
+++ b/tests/run/test_specs.py
@@ -228,6 +228,115 @@ class TestRunSpecificationValidation:
         assert spec.pass_mode == "intra"
 
 
+class TestModelFamilyCheckpointDerivation:
+    """model_family gates real ligand/sidechain-atom injection in
+    host/_sampling_helper.py::_prepare_ligand_context, independent of checkpoint_id -- a
+    caller who set a LigandMPNN checkpoint_id but never touched model_family got weights
+    loaded correctly (get_topology_for_checkpoint already derives architecture from
+    checkpoint_id) while real ligand/sidechain context silently never reached the model
+    (found live 2026-07-14, tev_design necklace P2 campaign -- three of six model beads
+    sampled with zero real ligand/sidechain atoms, no crash, no error). These tests cover
+    __post_init__'s auto-derivation of model_family from checkpoint_id when unset, and
+    confirm an explicit caller value is never silently overridden.
+    """
+
+    def test_unset_model_family_derived_from_ligand_checkpoint(
+        self, minimal_run_spec_kwargs: dict
+    ) -> None:
+        """model_family=None (unset) + a ligandmpnn checkpoint_id derives 'ligandmpnn'."""
+        spec = RunSpecification(
+            **minimal_run_spec_kwargs,
+            checkpoint_id="ligandmpnn_v_32_020_25",
+        )
+        assert spec.model_family == "ligandmpnn"
+
+    def test_unset_model_family_derived_from_packer_checkpoint(
+        self, minimal_run_spec_kwargs: dict
+    ) -> None:
+        """A dedicated SC/packer checkpoint (get_topology_for_checkpoint model_type='packer')
+        also derives 'ligandmpnn', matching _prepare_ligand_context's ligand-family gate.
+        """
+        spec = RunSpecification(
+            **minimal_run_spec_kwargs,
+            checkpoint_id="ligandmpnn_sc_v_32_020_25",
+        )
+        assert spec.model_family == "ligandmpnn"
+
+    def test_unset_model_family_stays_proteinmpnn_for_protein_checkpoint(
+        self, minimal_run_spec_kwargs: dict
+    ) -> None:
+        """model_family=None + a proteinmpnn checkpoint_id resolves to 'proteinmpnn'."""
+        spec = RunSpecification(
+            **minimal_run_spec_kwargs,
+            checkpoint_id="proteinmpnn_v_48_020",
+        )
+        assert spec.model_family == "proteinmpnn"
+
+    def test_unset_model_family_stays_proteinmpnn_with_no_checkpoint_id(
+        self, minimal_run_spec_kwargs: dict
+    ) -> None:
+        """model_family=None with no checkpoint_id at all falls back to the historical
+        'proteinmpnn' default -- no checkpoint_id means nothing to derive from.
+        """
+        spec = RunSpecification(**minimal_run_spec_kwargs)
+        assert spec.checkpoint_id is None
+        assert spec.model_family == "proteinmpnn"
+
+    def test_explicit_model_family_never_silently_overridden(
+        self, minimal_run_spec_kwargs: dict, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An explicit model_family='proteinmpnn' is respected even with a LigandMPNN
+        checkpoint_id (e.g. a deliberate ablation) -- this is the exact regression this test
+        suite exists to catch: an earlier version of this fix used the string default
+        "proteinmpnn" as its trigger condition and could not distinguish "caller explicitly
+        chose proteinmpnn" from "caller never set it", silently overriding real explicit
+        intent. A loud warning is still expected, since this combination is unusual.
+        """
+        with caplog.at_level("WARNING"):
+            spec = RunSpecification(
+                **minimal_run_spec_kwargs,
+                checkpoint_id="ligandmpnn_v_32_020_25",
+                model_family="proteinmpnn",
+            )
+        assert spec.model_family == "proteinmpnn"
+        assert any(
+            "explicitly set to 'proteinmpnn'" in record.message for record in caplog.records
+        )
+
+    def test_explicit_model_family_ligandmpnn_respected_no_warning(
+        self, minimal_run_spec_kwargs: dict, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An explicit model_family matching the checkpoint's real family is respected and
+        does not warn (nothing anomalous about this combination).
+        """
+        with caplog.at_level("WARNING"):
+            spec = RunSpecification(
+                **minimal_run_spec_kwargs,
+                checkpoint_id="ligandmpnn_v_32_020_25",
+                model_family="ligandmpnn",
+            )
+        assert spec.model_family == "ligandmpnn"
+        assert not any(
+            "model_family" in record.message.lower() and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+
+    def test_sampling_specification_also_derives(self, minimal_sampling_kwargs: dict) -> None:
+        """SamplingSpecification (a RunSpecification subclass, used by the real
+        `aminx campaign plan/run` pipeline) also gets the derivation via
+        super().__post_init__() -- this is the actual code path that was broken in
+        production, not just the base class in isolation.
+        """
+        spec = SamplingSpecification(
+            **minimal_sampling_kwargs,
+            checkpoint_id="ligandmpnn_v_32_020_25",
+            batch_size=4,
+            samples_chunk_size=20,
+            return_logits=False,
+        )
+        assert spec.model_family == "ligandmpnn"
+
+
 # ============================================================================
 # ScoringSpecification Tests
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aminx"
-version = "0.1.0a12"
+version = "0.1.0a15"
 source = { editable = "." }
 dependencies = [
     { name = "array-record", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary
- `model_family` gates real ligand-atom AND sidechain-atom injection in `_prepare_ligand_context`, completely independently of `checkpoint_id` — a caller who set a LigandMPNN `checkpoint_id` but never touched `model_family` got that checkpoint's weights loaded correctly (`get_topology_for_checkpoint` already derives architecture from `checkpoint_id`) while real ligand/sidechain context was silently never passed to the model. No crash, no error — architecturally indistinguishable from sampling an apo structure.
- Found live 2026-07-14 in tev_design's necklace P2 campaign while spot-checking a completed production regeneration: 3 of 6 model beads (`ligand_only`, `sc_only`, `ligand_and_sc`) sampled through `aminx campaign plan/run` with zero real ligand/sidechain atoms. Full trace: `tev_design/.praxia/docs/audits/260714_ligand-conditioning-model-family-bug.md`.
- **This is the project's third occurrence of the same failure class** (SC-null 2026-06-11 → Stage 3 bug F "E==F==G identical" 2026-06-22 → this) — the prior two fixes were per-instance and didn't touch this code path.

## Fix
- `model_family`'s default changes from `"proteinmpnn"` to `None`, so `__post_init__` can distinguish "never set" from "explicitly set to proteinmpnn" — an earlier version of this fix used the string default as its trigger and (caught by its own test) couldn't tell those apart, silently overriding real explicit intent.
- Only the `None` case is auto-derived from `checkpoint_id`, reusing `io/weights.py::get_topology_for_checkpoint` — the same classifier `load_model` already trusts for weight selection.
- An explicit `model_family` is always respected. If it disagrees with what `checkpoint_id` implies, a loud warning fires (covers a deliberate ablation or a real mistake — either way, never silent).

## Test plan
- [x] 10 new regression tests added (`tests/run/test_specs.py::TestModelFamilyCheckpointDerivation`, `tests/host/test_sampling_helper.py::TestPrepareLigandContextModelFamilyGate`)
- [x] Verified 6 of the 10 tests fail without the fix (temporarily reverted `specs.py`, reran) and pass with it — confirms they catch the actual regression
- [x] Full suite: 1484 passed, 14 skipped, 1 xpassed, 0 regressions, 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)