### PR TITLE
chore: bump version 0.1.0a15 -> 0.1.0a16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a15"
+version = "0.1.0a16"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aminx"
-version = "0.1.0a15"
+version = "0.1.0a16"
 source = { editable = "." }
 dependencies = [
     { name = "array-record", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
Version bump only, no code changes -- picks up merged PR #104 (model_family checkpoint-derivation fix).