### PR TITLE
fix: wire ligand_context_path through campaign plan CLI and manifest

### DIFF
--- a/src/aminx/cli.py
+++ b/src/aminx/cli.py
@@ -1676,6 +1676,20 @@ def campaign_plan(
       ),
     ),
   ] = None,
+  ligand_context_path: Annotated[
+    Path | None,
+    _OPT(
+      "--ligand-context-path",
+      help=(
+        "Path to a keyed npz file supplying real Y/Y_t/Y_m ligand-atom-cloud "
+        "tensors, forwarded to SamplingSpecification.ligand_context_path (see "
+        "aminx.run.specs.SamplingSpecification.ligand_context_path / "
+        "aminx.host._sampling_helper._load_ligand_context_file for the expected "
+        "'<structure_id>::Y', '<structure_id>::Y_t', '<structure_id>::Y_m' keying "
+        "convention, structure_id = Path(input_path).stem)."
+      ),
+    ),
+  ] = None,
 ) -> None:
   """Generate campaign manifest JSON."""
   from aminx.host.campaign import (  # noqa: PLC0415
@@ -1690,6 +1704,7 @@ def campaign_plan(
     return_logits=False,
     **({"checkpoint_id": checkpoint_id} if checkpoint_id is not None else {}),
     **({"chain_id": parsed_chain_id} if parsed_chain_id is not None else {}),
+    **({"ligand_context_path": ligand_context_path} if ligand_context_path is not None else {}),
   )
   write_campaign_manifest(
     base_spec=base_spec,

--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -661,6 +661,11 @@ def plan_campaign_manifest(
               "ligand_conditioning": ligand_on,
               "sidechain_conditioning": sidechain_on,
               "chain_id": spec_variant.chain_id,
+              "ligand_context_path": (
+                str(spec_variant.ligand_context_path)
+                if spec_variant.ligand_context_path
+                else None
+              ),
               "temperature": list(spec_variant.temperature),
               "backbone_noise": list(spec_variant.backbone_noise),
               "batch_size": spec_variant.batch_size,

--- a/tests/cli/test_campaign.py
+++ b/tests/cli/test_campaign.py
@@ -134,3 +134,78 @@ def test_campaign_plan_without_chain_id_omits_it(tmp_path: Path) -> None:
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     for row in payload["rows"]:
         assert row["sampling_spec"]["chain_id"] is None
+
+
+def test_campaign_plan_ligand_context_path_round_trips(tmp_path: Path) -> None:
+    """--ligand-context-path reaches every row's sampling_spec and survives reload.
+
+    Round-trips through SamplingSpecification(**row["sampling_spec"]) to confirm
+    the string written to the manifest reconstructs into a real ligand_context_path
+    (coerced to Path by RunSpecification's field normalization), not silently
+    dropped or left as some other type -- this mirrors the model_family wiring gap
+    (aminx PR #104) where a field was accepted by the CLI/spec but never reached the
+    manifest row.
+    """
+    from aminx.run.specs import SamplingSpecification  # noqa: PLC0415
+
+    manifest_path = tmp_path / "test.manifest.json"
+    output_root = tmp_path / "outputs"
+    fake_ligand_path = tmp_path / "fake_ligand_context.npz"
+
+    result = runner.invoke(
+        app,
+        [
+            "campaign",
+            "plan",
+            "--inputs", "fake.pdb",
+            "--campaign-id", "test",
+            "--manifest-path", str(manifest_path),
+            "--output-root", str(output_root),
+            "--designs-per-library-type", "1",
+            "--samples-chunk-size", "1",
+            "--checkpoint-id", "test-checkpoint-v1",
+            "--ligand-context-path", str(fake_ligand_path),
+        ],
+    )
+
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\nOutput:\n{result.output}"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = payload.get("rows", [])
+    assert len(rows) >= 1
+    for row in rows:
+        assert row["sampling_spec"]["ligand_context_path"] == str(fake_ligand_path)
+        reconstructed = SamplingSpecification(**row["sampling_spec"])
+        assert reconstructed.ligand_context_path == fake_ligand_path
+        assert isinstance(reconstructed.ligand_context_path, Path)
+
+
+def test_campaign_plan_without_ligand_context_path_omits_it(tmp_path: Path) -> None:
+    """Default (no --ligand-context-path) behavior: field stays None, not dropped/misdefaulted."""
+    from aminx.run.specs import SamplingSpecification  # noqa: PLC0415
+
+    manifest_path = tmp_path / "test.manifest.json"
+    output_root = tmp_path / "outputs"
+
+    result = runner.invoke(
+        app,
+        [
+            "campaign",
+            "plan",
+            "--inputs", "fake.pdb",
+            "--campaign-id", "test",
+            "--manifest-path", str(manifest_path),
+            "--output-root", str(output_root),
+            "--designs-per-library-type", "1",
+            "--samples-chunk-size", "1",
+            "--checkpoint-id", "test-checkpoint-v1",
+        ],
+    )
+
+    assert result.exit_code == 0, f"Expected exit 0, got {result.exit_code}.\nOutput:\n{result.output}"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = payload.get("rows", [])
+    assert len(rows) >= 1
+    for row in rows:
+        assert row["sampling_spec"]["ligand_context_path"] is None
+        reconstructed = SamplingSpecification(**row["sampling_spec"])
+        assert reconstructed.ligand_context_path is None

--- a/tests/host/test_sampling_helper.py
+++ b/tests/host/test_sampling_helper.py
@@ -7,11 +7,18 @@ what actually gates real ligand/sidechain-atom injection.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from aminx.host._sampling_helper import _prepare_fixed_controls, _prepare_ligand_context
+from aminx.host._sampling_helper import (
+    _canonical_structure_ids_for_spec,
+    _load_ligand_context_file,
+    _prepare_fixed_controls,
+    _prepare_ligand_context,
+)
 from aminx.run.specs import SamplingSpecification
 from aminx.utils.data_structures import Protein
 
@@ -268,3 +275,261 @@ class TestPrepareLigandContextModelFamilyGate:
     )
     assert ligand_context["atom_37"] is None
     assert ligand_context["Y"] is None
+
+
+def _write_keyed_npz(
+    path: Path,
+    payload: dict[str, dict[str, np.ndarray]],
+) -> None:
+  """payload: {structure_id: {"Y": arr, "Y_t": arr, "Y_m": arr}, ...}."""
+  flat: dict[str, np.ndarray] = {}
+  for structure_id, tensors in payload.items():
+    for tensor_name, arr in tensors.items():
+      flat[f"{structure_id}::{tensor_name}"] = arr
+  np.savez(path, **flat)
+
+
+def _make_ligand_tensors(
+    rng: np.random.Generator, seq_len: int, atoms: int,
+) -> dict[str, np.ndarray]:
+  return {
+      "Y": rng.standard_normal((seq_len, atoms, 3)).astype(np.float32),
+      "Y_t": rng.integers(1, 20, size=(seq_len, atoms)).astype(np.int64),
+      "Y_m": np.ones((seq_len, atoms), dtype=np.float32),
+  }
+
+
+class TestLoadLigandContextFileKeyedFormat:
+  """Keyed npz format: '<structure_id>::Y' / '<structure_id>::Y_t' / '<structure_id>::Y_m'.
+
+  Covers the round-trip stacking/ordering contract of _load_ligand_context_file
+  (src/aminx/host/_sampling_helper.py:123-243) for the '::'-separated keying convention,
+  and both its strict error paths (missing tensors, id mismatch between the npz payload
+  and the canonical structure roster).
+  """
+
+  def test_round_trip_two_structures_preserves_values_and_shapes(self, tmp_path: Path):
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(0)
+    tensors_a = _make_ligand_tensors(rng, seq_len, atoms)
+    tensors_b = _make_ligand_tensors(rng, seq_len, atoms)
+    path = tmp_path / "ligand_context.npz"
+    _write_keyed_npz(path, {"struct_a": tensors_a, "struct_b": tensors_b})
+
+    Y, Y_t, Y_m = _load_ligand_context_file(
+        path,
+        canonical_structure_ids=["struct_a", "struct_b"],
+        batch_structure_ids=["struct_a", "struct_b"],
+    )
+
+    assert Y.shape == (2, seq_len, atoms, 3)
+    assert Y_t.shape == (2, seq_len, atoms)
+    assert Y_m.shape == (2, seq_len, atoms)
+    np.testing.assert_array_equal(np.asarray(Y[0]), tensors_a["Y"])
+    np.testing.assert_array_equal(np.asarray(Y[1]), tensors_b["Y"])
+    np.testing.assert_array_equal(np.asarray(Y_t[0]), tensors_a["Y_t"])
+    np.testing.assert_array_equal(np.asarray(Y_m[1]), tensors_b["Y_m"])
+
+  def test_batch_structure_ids_controls_stacking_order_independent_of_canonical_order(
+      self, tmp_path: Path,
+  ):
+    """batch_structure_ids (not canonical_structure_ids, and not npz insertion order)
+    determines the order rows are stacked in -- this is the order kernel_dispatch.py's
+    real per-chunk batch relies on to line up ligand context rows with structure rows.
+    """
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(1)
+    tensors_a = _make_ligand_tensors(rng, seq_len, atoms)
+    tensors_b = _make_ligand_tensors(rng, seq_len, atoms)
+    path = tmp_path / "ligand_context.npz"
+    _write_keyed_npz(path, {"struct_a": tensors_a, "struct_b": tensors_b})
+
+    # canonical roster order is [a, b]; this batch's row order is reversed: [b, a]
+    Y, Y_t, Y_m = _load_ligand_context_file(
+        path,
+        canonical_structure_ids=["struct_a", "struct_b"],
+        batch_structure_ids=["struct_b", "struct_a"],
+    )
+
+    np.testing.assert_array_equal(np.asarray(Y[0]), tensors_b["Y"])
+    np.testing.assert_array_equal(np.asarray(Y[1]), tensors_a["Y"])
+
+  def test_missing_tensor_key_raises_value_error(self, tmp_path: Path):
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(2)
+    tensors_a = _make_ligand_tensors(rng, seq_len, atoms)
+    tensors_b = _make_ligand_tensors(rng, seq_len, atoms)
+    del tensors_b["Y_m"]  # struct_b is missing its Y_m tensor
+    path = tmp_path / "ligand_context.npz"
+    _write_keyed_npz(path, {"struct_a": tensors_a, "struct_b": tensors_b})
+
+    with pytest.raises(ValueError, match="missing keyed tensors"):
+      _load_ligand_context_file(
+          path,
+          canonical_structure_ids=["struct_a", "struct_b"],
+          batch_structure_ids=None,
+      )
+
+  def test_extra_structure_id_in_npz_raises_value_error(self, tmp_path: Path):
+    """npz has a structure the canonical roster doesn't -- must fail loudly, not silently
+    ignore the extra data or silently accept a roster mismatch.
+    """
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(3)
+    tensors_a = _make_ligand_tensors(rng, seq_len, atoms)
+    tensors_b = _make_ligand_tensors(rng, seq_len, atoms)
+    path = tmp_path / "ligand_context.npz"
+    _write_keyed_npz(path, {"struct_a": tensors_a, "struct_b": tensors_b})
+
+    with pytest.raises(ValueError, match="must exactly match canonical structure IDs"):
+      _load_ligand_context_file(
+          path,
+          canonical_structure_ids=["struct_a"],
+          batch_structure_ids=None,
+      )
+
+  def test_missing_structure_id_in_npz_raises_value_error(self, tmp_path: Path):
+    """canonical roster expects a structure the npz doesn't have -- must fail loudly."""
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(4)
+    tensors_a = _make_ligand_tensors(rng, seq_len, atoms)
+    path = tmp_path / "ligand_context.npz"
+    _write_keyed_npz(path, {"struct_a": tensors_a})
+
+    with pytest.raises(ValueError, match="must exactly match canonical structure IDs"):
+      _load_ligand_context_file(
+          path,
+          canonical_structure_ids=["struct_a", "struct_b"],
+          batch_structure_ids=None,
+      )
+
+
+class TestLoadLigandContextFileLegacyFormat:
+  """Legacy npz format: flat 'Y'/'Y_t'/'Y_m' arrays + a parallel 'structure_ids' array.
+
+  _load_ligand_context_file supports this format as a fallback when no '<id>::Y'-style
+  keys are found in the npz (src/aminx/host/_sampling_helper.py:213-244).
+  """
+
+  def test_round_trip_two_structures_preserves_values_and_reorders_by_batch_ids(
+      self, tmp_path: Path,
+  ):
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(5)
+    Y = rng.standard_normal((2, seq_len, atoms, 3)).astype(np.float32)
+    Y_t = rng.integers(1, 20, size=(2, seq_len, atoms)).astype(np.int64)
+    Y_m = np.ones((2, seq_len, atoms), dtype=np.float32)
+    path = tmp_path / "legacy.npz"
+    np.savez(
+        path,
+        Y=Y,
+        Y_t=Y_t,
+        Y_m=Y_m,
+        structure_ids=np.array(["struct_a", "struct_b"]),
+    )
+
+    out_Y, out_Y_t, out_Y_m = _load_ligand_context_file(
+        path,
+        canonical_structure_ids=["struct_a", "struct_b"],
+        batch_structure_ids=["struct_b", "struct_a"],
+    )
+
+    assert out_Y.shape == (2, seq_len, atoms, 3)
+    np.testing.assert_array_equal(np.asarray(out_Y[0]), Y[1])  # struct_b first
+    np.testing.assert_array_equal(np.asarray(out_Y[1]), Y[0])  # struct_a second
+    np.testing.assert_array_equal(np.asarray(out_Y_t[0]), Y_t[1])
+    np.testing.assert_array_equal(np.asarray(out_Y_m[1]), Y_m[0])
+
+  def test_missing_required_key_raises_value_error(self, tmp_path: Path):
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(6)
+    Y = rng.standard_normal((1, seq_len, atoms, 3)).astype(np.float32)
+    Y_t = rng.integers(1, 20, size=(1, seq_len, atoms)).astype(np.int64)
+    path = tmp_path / "legacy_missing.npz"
+    np.savez(path, Y=Y, Y_t=Y_t, structure_ids=np.array(["struct_a"]))  # Y_m omitted
+
+    with pytest.raises(ValueError, match="missing required keys"):
+      _load_ligand_context_file(path, canonical_structure_ids=None, batch_structure_ids=None)
+
+  def test_structure_id_mismatch_raises_value_error(self, tmp_path: Path):
+    seq_len, atoms = 4, 3
+    rng = np.random.default_rng(7)
+    Y = rng.standard_normal((2, seq_len, atoms, 3)).astype(np.float32)
+    Y_t = rng.integers(1, 20, size=(2, seq_len, atoms)).astype(np.int64)
+    Y_m = np.ones((2, seq_len, atoms), dtype=np.float32)
+    path = tmp_path / "legacy_mismatch.npz"
+    np.savez(
+        path,
+        Y=Y,
+        Y_t=Y_t,
+        Y_m=Y_m,
+        structure_ids=np.array(["struct_a", "struct_b"]),
+    )
+
+    with pytest.raises(ValueError, match="must exactly match canonical structure IDs"):
+      _load_ligand_context_file(
+          path,
+          canonical_structure_ids=["struct_a", "struct_c"],
+          batch_structure_ids=None,
+      )
+
+
+class TestPrepareLigandContextRequiresRealTensors:
+  """_prepare_ligand_context's ligand_conditioning=True enforcement -- the exact original
+  bug symptom this wiring fix addresses: a caller who asked for real ligand conditioning
+  but supplied no way to get real Y/Y_t/Y_m tensors (no ligand_context_path, no Y already
+  on the batch) must get a loud ValueError, not silently fall back to the zero-atom
+  placeholder used for the "no ligand conditioning requested" case.
+  """
+
+  def test_ligand_conditioning_without_any_source_raises(self):
+    batch_size, seq_len = 1, 4
+    protein = _make_fake_protein(batch_size=batch_size, seq_len=seq_len)
+
+    spec = SamplingSpecification(
+        inputs=["/tmp/struct_a.pdb"],
+        checkpoint_id="ligandmpnn_v_32_020_25",
+        ligand_conditioning=True,
+    )
+    assert spec.model_family == "ligandmpnn"
+    assert spec.ligand_context_path is None
+
+    with pytest.raises(ValueError, match="ligand_conditioning=True requires ligand context"):
+      _prepare_ligand_context(spec, batched_ensemble=protein, batch_size=batch_size, seq_len=seq_len)
+
+  def test_ligand_conditioning_with_valid_ligand_context_path_succeeds(self, tmp_path: Path):
+    batch_size, seq_len, atoms = 1, 4, 3
+    protein = _make_fake_protein(batch_size=batch_size, seq_len=seq_len)
+    rng = np.random.default_rng(8)
+    tensors_a = _make_ligand_tensors(rng, seq_len, atoms)
+    path = tmp_path / "ligand_context.npz"
+    _write_keyed_npz(path, {"struct_a": tensors_a})
+
+    spec = SamplingSpecification(
+        inputs=["/tmp/struct_a.pdb"],
+        checkpoint_id="ligandmpnn_v_32_020_25",
+        ligand_conditioning=True,
+        ligand_context_path=path,
+    )
+    assert spec.model_family == "ligandmpnn"
+    # mirror the real caller in kernel_dispatch.py: derive canonical structure ids from
+    # spec.inputs rather than relying on _load_ligand_context_file's sorted-keys fallback.
+    canonical_ids = _canonical_structure_ids_for_spec(spec)
+    assert canonical_ids == ["struct_a"]
+
+    ligand_context = _prepare_ligand_context(
+        spec,
+        batched_ensemble=protein,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        canonical_structure_ids=canonical_ids,
+        batch_structure_ids=canonical_ids,
+    )
+
+    assert ligand_context["Y"] is not None
+    assert ligand_context["Y_t"] is not None
+    assert ligand_context["Y_m"] is not None
+    assert ligand_context["Y"].shape == (batch_size, seq_len, atoms, 3)
+    np.testing.assert_array_equal(np.asarray(ligand_context["Y"][0]), tensors_a["Y"])
+    np.testing.assert_array_equal(np.asarray(ligand_context["Y_t"][0]), tensors_a["Y_t"])
+    np.testing.assert_array_equal(np.asarray(ligand_context["Y_m"][0]), tensors_a["Y_m"])

--- a/tests/model/test_ligand_feature_tiling.py
+++ b/tests/model/test_ligand_feature_tiling.py
@@ -5,10 +5,31 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 # Internal imports: not public API
 from aminx.model.ligand_features import ProteinFeaturesLigand
 from aminx.model.ligand_tiling import map_chunks_axis0, map_chunks_axis0_multi
+
+# --- Analytic Cb offset for the canonical local backbone frame used below ---------------
+# ProteinFeaturesLigand computes a virtual Cb as:
+#   b = Ca - N; c = C - Ca; a = cross(b, c)
+#   Cb = -0.58273431*a + 0.56802827*b - 0.54067466*c + Ca
+# For the fixed local frame N=(0,0,0), Ca=(1,0,0), C=(1,1,0) (translated per-residue by T),
+# b=(1,0,0), c=(0,1,0), a=(0,0,1), so Cb = Ca + (0.56802827, -0.54067466, -0.58273431)
+# regardless of T (translation cancels out of b, c, a). This lets a test choose an exact
+# target Cb position per residue by solving T = target_cb - (1,0,0) - _CB_OFFSET.
+_CB_OFFSET = np.array([0.56802827, -0.54067466, -0.58273431])
+
+
+def _make_backbone_for_cb_targets(cb_targets: np.ndarray) -> jnp.ndarray:
+  """Build (L, 4, 3) N/Ca/C/O coordinates whose virtual Cb lands exactly on cb_targets."""
+  translation = cb_targets - np.array([1.0, 0.0, 0.0]) - _CB_OFFSET
+  n = translation
+  ca = translation + np.array([1.0, 0.0, 0.0])
+  c = translation + np.array([1.0, 1.0, 0.0])
+  o = translation + np.array([0.0, 1.0, 0.0])
+  return jnp.asarray(np.stack([n, ca, c, o], axis=1).astype(np.float32))
 
 
 def test_map_chunks_matches_dense_y_edges() -> None:
@@ -73,3 +94,317 @@ def test_map_chunks_matches_dense_y_nodes() -> None:
   )
 
   np.testing.assert_allclose(dense, tiled, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# M-scale regression: per-residue top-k ligand-atom selection (ligand_features.py:383-396).
+#
+# Existing fixtures above (and tests/model/test_ligandmpnn_equivalence.py) only exercise
+# M == atom_context_num, a no-op case for the top-k reduction (jax.lax.top_k(-dist, k) with
+# k == M just returns everything, sorted). Necklace's real production ligand context is
+# M=57-82 heavy atoms per state, well above atom_context_num (16 or 25) -- the exact regime
+# an earlier hardening cycle assumed was handled without verifying the mechanism at this
+# scale. These tests construct M=72 ligand atoms placed at known, controlled distances from
+# 3 residues' (analytically exact, see `_make_backbone_for_cb_targets`) Cb positions, and
+# check the real forward pass (`ProteinFeaturesLigand.__call__`) selects the correct subset.
+#
+# `e_idx_y` itself is not returned by `__call__` (it is consumed internally to gather
+# ligand_coords/types/mask before any downstream projection). So correctness is verified
+# by comparing full per-residue node features `V` from the wide M=72 context against V from
+# an independently-constructed "oracle" input pre-cropped (via a numpy argsort of exact
+# Euclidean distances, an independent code path from the model's `jax.lax.top_k`) to exactly
+# the ground-truth top-k atoms for that residue. Because ProteinFeaturesLigand.__call__ is a
+# pure function of only the k *selected* ligand atoms' coordinates/types (unselected atoms
+# provably cannot reach V at all -- see the third test below), exact numerical equivalence of
+# V between the two runs is only possible if the wide-context run selected exactly the same
+# set of atoms as the oracle.
+# ---------------------------------------------------------------------------
+
+
+def _line_ligand_atoms(num_atoms: int, spacing: float = 1.0) -> np.ndarray:
+  """M atoms strung out along +x at `spacing` Angstrom increments, y=z=0."""
+  x = np.arange(num_atoms) * spacing
+  return np.stack([x, np.zeros(num_atoms), np.zeros(num_atoms)], axis=-1).astype(np.float32)
+
+
+def _cb_targets_for_line(num_atoms: int, spacing: float = 1.0) -> np.ndarray:
+  """3 Cb targets relative to `_line_ligand_atoms`: far-left, far-right, near-middle.
+
+  Distances from each target to its nearest ~30 atoms stay within the RBF's calibrated
+  [2, 22] Angstrom range (see ProteinFeaturesLigand._rbf) so downstream features are not
+  saturated -- saturation would make a wrong atom selection numerically undetectable.
+  """
+  mid = (num_atoms - 1) / 2.0
+  return np.array(
+    [
+      [-3.0, 0.0, 0.0],  # residue 0: nearest = smallest indices, in ascending-index order
+      [(num_atoms - 1) * spacing + 3.0, 0.0, 0.0],  # residue 1: nearest = largest indices
+      [mid * spacing + 0.37, 5.0, 0.0],  # residue 2: near middle; asymmetric offset avoids ties
+    ],
+  )
+
+
+def _ground_truth_topk(
+  cb_targets: np.ndarray,
+  ligand_atoms: np.ndarray,
+  k: int,
+  ligand_mask: np.ndarray | None = None,
+) -> np.ndarray:
+  """Independent (pure-numpy) nearest-k computation: argsort of exact Euclidean distance.
+
+  Deliberately does not call jax.lax.top_k or any code from ligand_features.py -- this is
+  the ground-truth oracle the model's own top-k selection is checked against.
+  """
+  dists = np.linalg.norm(cb_targets[:, None, :] - ligand_atoms[None, :, :], axis=-1)
+  if ligand_mask is not None:
+    dists = np.where(ligand_mask > 0, dists, np.inf)
+  order = np.argsort(dists, axis=1)
+  d_sorted = np.take_along_axis(dists, order, axis=1)
+  boundary_gap = d_sorted[:, k] - d_sorted[:, k - 1]
+  assert np.all(boundary_gap > 1e-6), (
+    f"ground-truth top-{k} has a tie at the selection boundary for residue(s) "
+    f"{np.nonzero(boundary_gap <= 1e-6)[0].tolist()} -- test geometry is ambiguous."
+  )
+  return order[:, :k]
+
+
+def _make_features(atom_context_num: int, *, seed: int = 123) -> ProteinFeaturesLigand:
+  return ProteinFeaturesLigand(
+    node_features=32,
+    edge_features=32,
+    k_neighbors=3,
+    atom_context_num=atom_context_num,
+    ligand_l_chunk=-1,
+    key=jax.random.PRNGKey(seed),
+  )
+
+
+@pytest.mark.parametrize("atom_context_num", [16, 25])
+def test_topk_ligand_selection_matches_oracle_at_necklace_scale(atom_context_num: int) -> None:
+  """At M=72 (necklace production scale), top-k selection picks the analytically-correct atoms.
+
+  For 3 residues with exactly-known Cb positions, compares V from the real forward pass at
+  M=72 against V from an oracle forward pass pre-cropped to the ground-truth top-k (a no-op
+  M==atom_context_num case, like the pre-existing fixtures -- but now used as a checked
+  oracle instead of the only case tested).
+  """
+  num_atoms = 72
+  feat = _make_features(atom_context_num)
+
+  cb_targets = _cb_targets_for_line(num_atoms)
+  structure_coordinates = _make_backbone_for_cb_targets(cb_targets)
+  num_residues = cb_targets.shape[0]
+  mask = jnp.ones((num_residues,))
+  residue_index = jnp.arange(num_residues)
+  chain_index = jnp.zeros((num_residues,), dtype=jnp.int32)
+
+  ligand_atoms = _line_ligand_atoms(num_atoms)
+  top_idx = _ground_truth_topk(cb_targets, ligand_atoms, atom_context_num)
+
+  # Sanity-check residue 0's ground truth is exactly the hand-predicted set: nearest atoms
+  # to a Cb 3 Angstrom to the "left" of a line starting at atom 0 are atoms 0..k-1.
+  assert sorted(top_idx[0].tolist()) == list(range(atom_context_num))
+  # Residue 1 (mirrored): nearest atoms are the last k atoms on the line.
+  assert sorted(top_idx[1].tolist()) == list(range(num_atoms - atom_context_num, num_atoms))
+
+  ligand_coords_wide = jnp.broadcast_to(jnp.asarray(ligand_atoms)[None], (num_residues, num_atoms, 3))
+  types_wide = jnp.zeros((num_residues, num_atoms), dtype=jnp.int32)
+  mask_wide = jnp.ones((num_residues, num_atoms))
+
+  v_wide, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    ligand_coords_wide,
+    types_wide,
+    mask_wide,
+    0.0,
+    None,
+  )
+  assert v_wide.shape == (num_residues, atom_context_num, 32)
+  assert np.all(np.isfinite(np.asarray(v_wide))), "no shape blowup/NaN at M=72 necklace scale"
+
+  ligand_coords_oracle = jnp.asarray(ligand_atoms[top_idx])
+  types_oracle = jnp.zeros((num_residues, atom_context_num), dtype=jnp.int32)
+  mask_oracle = jnp.ones((num_residues, atom_context_num))
+
+  v_oracle, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    ligand_coords_oracle,
+    types_oracle,
+    mask_oracle,
+    0.0,
+    None,
+  )
+
+  np.testing.assert_allclose(
+    np.asarray(v_wide),
+    np.asarray(v_oracle),
+    rtol=1e-5,
+    atol=1e-5,
+    err_msg=(
+      f"V from the wide M={num_atoms} context does not match V from the ground-truth "
+      f"top-{atom_context_num} oracle crop -- the real top-k selection picked the wrong "
+      "atoms at necklace production scale."
+    ),
+  )
+
+
+def test_topk_ligand_selection_respects_ligand_mask() -> None:
+  """Masked-out atoms are excluded from top-k selection even when geometrically nearest.
+
+  Masks out the single nearest atom to residue 0's Cb; the correct new top-16 must be the
+  *next* 16 nearest (atoms 1..16), not e.g. the original top-16 including the masked atom.
+  """
+  num_atoms, k = 72, 16
+  feat = _make_features(k)
+
+  cb_targets = _cb_targets_for_line(num_atoms)
+  structure_coordinates = _make_backbone_for_cb_targets(cb_targets)
+  num_residues = cb_targets.shape[0]
+  mask = jnp.ones((num_residues,))
+  residue_index = jnp.arange(num_residues)
+  chain_index = jnp.zeros((num_residues,), dtype=jnp.int32)
+
+  ligand_atoms = _line_ligand_atoms(num_atoms)
+  ligand_mask_np = np.ones((num_residues, num_atoms), dtype=np.float32)
+  ligand_mask_np[0, 0] = 0.0  # mask out residue 0's single nearest atom
+
+  top_idx = _ground_truth_topk(cb_targets, ligand_atoms, k, ligand_mask=ligand_mask_np)
+  assert 0 not in top_idx[0].tolist(), "ground-truth oracle setup error: masked atom leaked in"
+  assert sorted(top_idx[0].tolist()) == list(range(1, k + 1))
+
+  ligand_coords_wide = jnp.broadcast_to(jnp.asarray(ligand_atoms)[None], (num_residues, num_atoms, 3))
+  types_wide = jnp.zeros((num_residues, num_atoms), dtype=jnp.int32)
+
+  v_masked, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    ligand_coords_wide,
+    types_wide,
+    jnp.asarray(ligand_mask_np),
+    0.0,
+    None,
+  )
+
+  ligand_coords_oracle = jnp.asarray(ligand_atoms[top_idx])
+  types_oracle = jnp.zeros((num_residues, k), dtype=jnp.int32)
+  mask_oracle = jnp.ones((num_residues, k))
+
+  v_oracle, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    ligand_coords_oracle,
+    types_oracle,
+    mask_oracle,
+    0.0,
+    None,
+  )
+
+  np.testing.assert_allclose(
+    np.asarray(v_masked),
+    np.asarray(v_oracle),
+    rtol=1e-5,
+    atol=1e-5,
+    err_msg="masked-out nearest atom was not correctly excluded from top-k selection.",
+  )
+
+
+def test_topk_ligand_selection_only_selected_atoms_influence_node_features() -> None:
+  """Differential check: perturbing a selected atom changes V; perturbing an excluded one does not.
+
+  This is a non-vacuous confirmation that the oracle-matching tests above are actually
+  sensitive to selection correctness, and not an artifact of some degenerate no-op path
+  (e.g. RBF saturation): distances here are kept within the RBF's calibrated [2, 22]
+  Angstrom range so a wrong selection is numerically detectable.
+  """
+  num_atoms, k = 72, 16
+  feat = _make_features(k)
+
+  cb_targets = _cb_targets_for_line(num_atoms)
+  structure_coordinates = _make_backbone_for_cb_targets(cb_targets)
+  num_residues = cb_targets.shape[0]
+  mask = jnp.ones((num_residues,))
+  residue_index = jnp.arange(num_residues)
+  chain_index = jnp.zeros((num_residues,), dtype=jnp.int32)
+
+  ligand_atoms = _line_ligand_atoms(num_atoms)
+  top_idx = _ground_truth_topk(cb_targets, ligand_atoms, k)
+
+  types_wide = jnp.zeros((num_residues, num_atoms), dtype=jnp.int32)
+  mask_wide = jnp.ones((num_residues, num_atoms))
+  ligand_coords_wide = jnp.broadcast_to(jnp.asarray(ligand_atoms)[None], (num_residues, num_atoms, 3))
+
+  v_wide, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    ligand_coords_wide,
+    types_wide,
+    mask_wide,
+    0.0,
+    None,
+  )
+
+  # Mutate the farthest currently-selected atom for residue 0 far outside the RBF range --
+  # this must knock it out of the top-16 (replaced by the next-nearest unselected atom) and
+  # change V[0].
+  selected_boundary_atom = int(top_idx[0, -1])
+  mutated_selected = ligand_atoms.copy()
+  mutated_selected[selected_boundary_atom, 0] += 50.0
+  v_mut_selected, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    jnp.broadcast_to(jnp.asarray(mutated_selected)[None], (num_residues, num_atoms, 3)),
+    types_wide,
+    mask_wide,
+    0.0,
+    None,
+  )
+  changed = np.abs(np.asarray(v_mut_selected[0]) - np.asarray(v_wide[0])).max()
+  assert changed > 1e-3, (
+    "mutating a selected boundary atom did not change V -- top-k selection may not be "
+    "responding to distance at necklace scale."
+  )
+
+  # Mutate an atom that is nowhere near residue 0's Cb (already unselected, already far
+  # outside the RBF range) -- V[0] must be completely unaffected, since unselected atoms
+  # cannot reach V by construction (they are dropped before any downstream projection).
+  far_unselected_atom = 50
+  assert far_unselected_atom not in top_idx[0].tolist()
+  mutated_unselected = ligand_atoms.copy()
+  mutated_unselected[far_unselected_atom, 0] += 50.0
+  v_mut_unselected, *_ = feat(
+    jax.random.PRNGKey(0),
+    structure_coordinates,
+    mask,
+    residue_index,
+    chain_index,
+    jnp.broadcast_to(jnp.asarray(mutated_unselected)[None], (num_residues, num_atoms, 3)),
+    types_wide,
+    mask_wide,
+    0.0,
+    None,
+  )
+  unchanged = np.abs(np.asarray(v_mut_unselected[0]) - np.asarray(v_wide[0])).max()
+  assert unchanged == 0.0, (
+    "mutating an atom far outside residue 0's top-k selection changed V[0] -- an "
+    "unselected atom is leaking into the selected feature computation."
+  )


### PR DESCRIPTION
## Summary
- `campaign plan`'s CLI never exposed `--ligand-context-path` (only `aminx run`/`aminx spec` did) -- fixed, mirrors the existing `--chain-id` conditional-inclusion pattern.
- `plan_campaign_manifest`'s per-row `sampling_spec` dict literal silently dropped `ligand_context_path` even when set on `base_spec` -- fixed, follows the same `Path`-stringification pattern as the adjacent `checkpoint_registry_path` entry.
- Confirmed via direct trace this closes the gap on the real production dispatch path (`run_manifest_row` -> `SamplingSpecification(**worker_payload)` from the persisted manifest row), not just the planning step.

## Tests
- Round-trip test for both fixes together (CLI -> JSON manifest -> `SamplingSpecification` reconstruction), including the negative case (field stays unset when the flag isn't passed).
- Real M-scale regression test for `ligand_features.py`'s per-residue top-k reduction at M=72 (existing fixtures only covered `M == atom_context_num`, a no-op case for this exact reduction) -- independently-derived, non-trivial ground-truth geometry, verified sensitive via injected-bug testing (4/7 tests fail if the top-k selects farthest instead of nearest atoms).
- End-to-end tests for `_load_ligand_context_file`/`_prepare_ligand_context`: keyed-npz round-trip, missing/extra-key error paths, confirming `ligand_conditioning=True` no longer raises once `ligand_context_path` is set.

Full suite: 1515 passed, 0 failures, 0 regressions (prior baseline 1494).

## Independent audit
APPROVE (with one trivial docstring fix applied before this PR). Confirmed:
- Both fixes correct and propagate through the real production path.
- New tests are genuinely sensitive (verified via injected-bug testing), not "doesn't crash" checks.
- No other CLI entry point shares this gap, **except** a pre-existing, structurally-identical one in `campaign ramp-plan` (`campaign_ramp_plan` builds its own `SamplingSpecification` but exposes neither `--ligand-context-path` nor `--chain-id`) -- not introduced by this change, tracked as a follow-up, not fixed here (out of scope for the immediate necklace-campaign need).

## Test plan
- [x] Full aminx test suite (1515 passed, 0 failures)
- [x] Independent adversarial audit (APPROVE)
- [x] Injected-bug sensitivity check on the new M-scale test
- [x] Stash-based negative test confirming the round-trip test fails without the fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>