### PR TITLE
chore: bump version 0.1.0a16 -> 0.1.0a17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a16"
+version = "0.1.0a17"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
Version-bump-only commit for #106 (ligand_context_path wiring fix + M-scale regression test).