### PR TITLE
audit: mechanical control-knob matrix for the campaign spec surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ markers = [
     "phase0a_spike: Phase 0a state_vmap_exact vs explicit vmap stack (roadmap REFACTOR_ROADMAP §227)",
     "requires_weights: test requires model weight files (bundled or HF Hub)",
     "knob_differential: control-knob reachability through the real CLI/manifest/spec/runner path",
+    "alphabet_boundary: AF-vs-MPNN convention at a real parse/model boundary (never a fixture)",
 ]
 
 [tool.ty.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ markers = [
     "parity_audit: checkpoint-family audit parity checks and conversion validation",
     "phase0a_spike: Phase 0a state_vmap_exact vs explicit vmap stack (roadmap REFACTOR_ROADMAP §227)",
     "requires_weights: test requires model weight files (bundled or HF Hub)",
+    "knob_differential: control-knob reachability through the real CLI/manifest/spec/runner path",
 ]
 
 [tool.ty.environment]

--- a/scripts/audit/knob_matrix.py
+++ b/scripts/audit/knob_matrix.py
@@ -24,18 +24,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Entry points that construct a spec. `campaign worker` is deliberately excluded from the
-# CLI columns: it takes zero spec flags by design (all content arrives from the manifest
-# row), so a "missing flag" there is correct, not a gap.
-CLI_COMMANDS = [
-  ("run", ["run"]),
-  ("run sample", ["run", "sample"]),
-  ("spec", ["spec"]),
-  ("spec emit-sample", ["spec", "emit-sample"]),
-  ("campaign plan", ["campaign", "plan"]),
-  ("campaign worker", ["campaign", "worker"]),
-  ("campaign ramp-plan", ["campaign", "ramp-plan"]),
-]
+# Entry points are DISCOVERED by walking the click tree, never hand-listed. An earlier
+# version of this script hardcoded seven command paths and silently audited 3 of the 6
+# campaign subcommands -- reproducing, in the audit tool itself, the exact hand-maintained-
+# list-drifts-from-reality bug it exists to find. Enumerate, don't enumerate-by-hand.
+MAX_DEPTH = 2
 
 
 def _git_ref(repo: Path) -> dict[str, str]:
@@ -66,36 +59,31 @@ def _spec_fields() -> dict[str, dict[str, Any]]:
 
 
 def _cli_params() -> dict[str, set[str]]:
-  """Map each command to the spec-field names it can set.
+  """Map every discovered command to the spec-field names it can set.
 
   Uses click's own param objects rather than parsing help text, so a flag cannot appear
-  present here unless it is genuinely registered on the command.
+  present here unless it is genuinely registered on the command. Groups (`run`, `spec`,
+  `campaign`) are reported too: their shared model flags live on the group callback, and a
+  subcommand inherits them only when invoked as `aminx run --flag sample`.
   """
   import typer.main
 
   from aminx.cli import app
 
-  root = typer.main.get_command(app)
   out: dict[str, set[str]] = {}
 
-  for label, path in CLI_COMMANDS:
-    cmd = root
-    ok = True
-    for part in path:
-      sub = getattr(cmd, "commands", {}).get(part)
-      if sub is None:
-        logger.warning("command path not found: %s", label)
-        ok = False
-        break
-      cmd = sub
-    if not ok:
-      continue
+  def walk(cmd: Any, path: list[str], depth: int) -> None:
+    label = " ".join(path) if path else "<root>"
+    if path:
+      out[label] = {p.name for p in cmd.params if p.name}
+    subs = getattr(cmd, "commands", None)
+    if not subs or depth >= MAX_DEPTH:
+      return
+    for name in sorted(subs):
+      walk(subs[name], [*path, name], depth + 1)
 
-    names = {p.name for p in cmd.params if p.name}
-    # `run`/`spec` are groups whose shared model flags live on the group callback; click
-    # exposes those on the group itself, which is what we just collected.
-    out[label] = names
-
+  walk(typer.main.get_command(app), [], 0)
+  logger.info("discovered %d CLI commands: %s", len(out), ", ".join(sorted(out)))
   return out
 
 
@@ -205,13 +193,14 @@ def build_matrix(repo: Path) -> dict[str, Any]:
       "array_coerced_on_decode": name in coercion,
       "read_under_host": reads.get(name, []),
     }
-    for label, _ in CLI_COMMANDS:
-      row[f"cli::{label}"] = name in cli.get(label, set())
+    for label in sorted(cli):
+      row[f"cli::{label}"] = name in cli[label]
     rows.append(row)
 
   return {
     "task_id": "260715_aminx-campaign-control-knob-audit",
     "aminx_ref": _git_ref(repo),
+    "cli_commands_discovered": sorted(cli),
     "field_count": len(rows),
     "manifest_dict_key_count": len(manifest_keys),
     # Keys written into the manifest that are not spec fields at all: these would raise
@@ -223,20 +212,23 @@ def build_matrix(repo: Path) -> dict[str, Any]:
 
 def summarize(matrix: dict[str, Any]) -> str:
   rows = matrix["rows"]
-  reachable_via_plan = [r for r in rows if r["cli::campaign plan"]]
+  # Subcommands only -- the bare "campaign" group carries no spec flags of its own.
+  campaign_cols = [c for c in matrix["cli_commands_discovered"] if c.startswith("campaign ")]
+  reachable_via_plan = [r for r in rows if r.get("cli::campaign plan")]
   in_manifest = [r for r in rows if r["in_manifest_dict"]]
-  # The core gap: a field that no campaign entry point can set AND that the manifest
-  # never carries is unreachable in campaign mode, whatever its default claims.
+  # The core gap: a field that NO campaign entry point can set and that the manifest never
+  # carries is unreachable in campaign mode, whatever its default claims.
   unreachable = [
     r for r in rows
     if not r["in_manifest_dict"]
-    and not r["cli::campaign plan"]
-    and not r["cli::campaign ramp-plan"]
+    and not any(r.get(f"cli::{c}") for c in campaign_cols)
   ]
   never_read = [r for r in rows if not r["read_under_host"]]
 
   lines = [
     f"aminx ref:            {matrix['aminx_ref']['describe']} ({matrix['aminx_ref']['head'][:10]})",
+    f"CLI commands found:   {len(matrix['cli_commands_discovered'])}"
+    f" ({len(campaign_cols)} campaign: {', '.join(c.split(' ', 1)[1] for c in campaign_cols)})",
     f"spec fields:          {matrix['field_count']}",
     f"manifest dict keys:   {matrix['manifest_dict_key_count']}",
     f"settable via plan:    {len(reachable_via_plan)}",

--- a/scripts/audit/knob_matrix.py
+++ b/scripts/audit/knob_matrix.py
@@ -1,0 +1,281 @@
+"""Emit the aminx control-knob matrix: spec field x entry point x hop.
+
+Produced for task_id 260715_aminx-campaign-control-knob-audit.
+
+Every cell is derived by introspecting the *installed* aminx (dataclass fields, Typer
+command params) or by AST-parsing aminx source -- never by reading prose or trusting a
+summary. The audit this feeds exists because seven control knobs were silently dropped
+between their declaration site and the model, and every one was found incidentally.
+
+Run under a venv with the audited aminx importable; the ref is reported in the output so
+a matrix can never be silently attributed to the wrong version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import logging
+import subprocess
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Entry points that construct a spec. `campaign worker` is deliberately excluded from the
+# CLI columns: it takes zero spec flags by design (all content arrives from the manifest
+# row), so a "missing flag" there is correct, not a gap.
+CLI_COMMANDS = [
+  ("run", ["run"]),
+  ("run sample", ["run", "sample"]),
+  ("spec", ["spec"]),
+  ("spec emit-sample", ["spec", "emit-sample"]),
+  ("campaign plan", ["campaign", "plan"]),
+  ("campaign worker", ["campaign", "worker"]),
+  ("campaign ramp-plan", ["campaign", "ramp-plan"]),
+]
+
+
+def _git_ref(repo: Path) -> dict[str, str]:
+  """Record exactly which ref this matrix describes."""
+  def _run(*args: str) -> str:
+    try:
+      return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
+      ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+      return "unknown"
+
+  return {"head": _run("rev-parse", "HEAD"), "describe": _run("describe", "--always", "--dirty")}
+
+
+def _spec_fields() -> dict[str, dict[str, Any]]:
+  from aminx.run.specs import RunSpecification, SamplingSpecification
+
+  base = {f.name for f in fields(RunSpecification)}
+  out: dict[str, dict[str, Any]] = {}
+  for f in fields(SamplingSpecification):
+    out[f.name] = {
+      "type": str(f.type),
+      "init": f.init,
+      "origin": "RunSpecification" if f.name in base else "SamplingSpecification",
+    }
+  return out
+
+
+def _cli_params() -> dict[str, set[str]]:
+  """Map each command to the spec-field names it can set.
+
+  Uses click's own param objects rather than parsing help text, so a flag cannot appear
+  present here unless it is genuinely registered on the command.
+  """
+  import typer.main
+
+  from aminx.cli import app
+
+  root = typer.main.get_command(app)
+  out: dict[str, set[str]] = {}
+
+  for label, path in CLI_COMMANDS:
+    cmd = root
+    ok = True
+    for part in path:
+      sub = getattr(cmd, "commands", {}).get(part)
+      if sub is None:
+        logger.warning("command path not found: %s", label)
+        ok = False
+        break
+      cmd = sub
+    if not ok:
+      continue
+
+    names = {p.name for p in cmd.params if p.name}
+    # `run`/`spec` are groups whose shared model flags live on the group callback; click
+    # exposes those on the group itself, which is what we just collected.
+    out[label] = names
+
+  return out
+
+
+def _dict_literal_keys(src: Path, target: str) -> set[str]:
+  """AST-extract the keys of the `row["sampling_spec"] = {...}` literal.
+
+  AST rather than regex: the point of this audit is that a hand-maintained literal drifts
+  from the dataclass, so the extraction of that literal must itself be exact.
+  """
+  tree = ast.parse(src.read_text())
+  found: set[str] = set()
+
+  for node in ast.walk(tree):
+    if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+      continue
+    for tgt in node.targets:
+      if (
+        isinstance(tgt, ast.Subscript)
+        and isinstance(tgt.slice, ast.Constant)
+        and tgt.slice.value == target
+      ):
+        for k in node.value.keys:
+          if isinstance(k, ast.Constant) and isinstance(k.value, str):
+            found.add(k.value)
+  return found
+
+
+def _named_set_literal(src: Path, names: tuple[str, ...]) -> set[str]:
+  """Extract string members of a module-level frozenset/set assignment."""
+  tree = ast.parse(src.read_text())
+  out: set[str] = set()
+  for node in ast.walk(tree):
+    if not isinstance(node, ast.Assign):
+      continue
+    tgt_names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+    if not tgt_names & set(names):
+      continue
+    for sub in ast.walk(node.value):
+      if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+        out.add(sub.value)
+  return out
+
+
+def _coercion_whitelist(src: Path) -> set[str]:
+  """Extract the array-coercion field names from `_coerce_field_value`.
+
+  These are the fields whose JSON lists become arrays on decode; a field absent here that
+  holds an array arrives as a plain list, silently.
+  """
+  tree = ast.parse(src.read_text())
+  out: set[str] = set()
+  for node in ast.walk(tree):
+    if not (isinstance(node, ast.FunctionDef) and node.name == "_coerce_field_value"):
+      continue
+    for sub in ast.walk(node):
+      # match: field_name in {"a", "b", ...}
+      if isinstance(sub, ast.Compare) and isinstance(sub.ops[0], ast.In):
+        for cmp in sub.comparators:
+          if isinstance(cmp, ast.Set):
+            for elt in cmp.elts:
+              if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                out.add(elt.value)
+  return out
+
+
+def _consumer_reads(src_root: Path, field_names: set[str]) -> dict[str, list[str]]:
+  """Find which fields are read as attributes anywhere under host/.
+
+  Heuristic and deliberately over-inclusive: it answers "is this field mentioned by any
+  consumer at all", so a field with an empty list here is a strong silent-no-op candidate.
+  It is a triage signal, never a verdict -- Phase 2's differential harness is the verdict.
+  """
+  hits: dict[str, set[str]] = {n: set() for n in field_names}
+  for py in sorted((src_root / "host").rglob("*.py")):
+    try:
+      tree = ast.parse(py.read_text())
+    except SyntaxError:
+      logger.warning("skipping unparseable file: %s", py)
+      continue
+    rel = str(py.relative_to(src_root))
+    for node in ast.walk(tree):
+      if isinstance(node, ast.Attribute) and node.attr in hits:
+        hits[node.attr].add(rel)
+  return {k: sorted(v) for k, v in hits.items()}
+
+
+def build_matrix(repo: Path) -> dict[str, Any]:
+  src_root = repo / "src" / "aminx"
+  campaign_py = src_root / "host" / "campaign.py"
+  spec_json_py = src_root / "run" / "spec_json.py"
+
+  spec = _spec_fields()
+  cli = _cli_params()
+  manifest_keys = _dict_literal_keys(campaign_py, "sampling_spec")
+  non_json = _named_set_literal(spec_json_py, ("_NON_JSON_ROOT_FIELDS",))
+  coercion = _coercion_whitelist(spec_json_py)
+  reads = _consumer_reads(src_root, set(spec))
+
+  rows = []
+  for name, meta in sorted(spec.items()):
+    row: dict[str, Any] = {
+      "field": name,
+      "origin": meta["origin"],
+      "type": meta["type"],
+      "in_manifest_dict": name in manifest_keys,
+      "spec_json_encodable": name not in non_json and meta["init"],
+      "array_coerced_on_decode": name in coercion,
+      "read_under_host": reads.get(name, []),
+    }
+    for label, _ in CLI_COMMANDS:
+      row[f"cli::{label}"] = name in cli.get(label, set())
+    rows.append(row)
+
+  return {
+    "task_id": "260715_aminx-campaign-control-knob-audit",
+    "aminx_ref": _git_ref(repo),
+    "field_count": len(rows),
+    "manifest_dict_key_count": len(manifest_keys),
+    # Keys written into the manifest that are not spec fields at all: these would raise
+    # TypeError at SamplingSpecification(**payload) unless deprecated-stripped.
+    "manifest_keys_not_spec_fields": sorted(manifest_keys - set(spec)),
+    "rows": rows,
+  }
+
+
+def summarize(matrix: dict[str, Any]) -> str:
+  rows = matrix["rows"]
+  reachable_via_plan = [r for r in rows if r["cli::campaign plan"]]
+  in_manifest = [r for r in rows if r["in_manifest_dict"]]
+  # The core gap: a field that no campaign entry point can set AND that the manifest
+  # never carries is unreachable in campaign mode, whatever its default claims.
+  unreachable = [
+    r for r in rows
+    if not r["in_manifest_dict"]
+    and not r["cli::campaign plan"]
+    and not r["cli::campaign ramp-plan"]
+  ]
+  never_read = [r for r in rows if not r["read_under_host"]]
+
+  lines = [
+    f"aminx ref:            {matrix['aminx_ref']['describe']} ({matrix['aminx_ref']['head'][:10]})",
+    f"spec fields:          {matrix['field_count']}",
+    f"manifest dict keys:   {matrix['manifest_dict_key_count']}",
+    f"settable via plan:    {len(reachable_via_plan)}",
+    f"carried in manifest:  {len(in_manifest)}",
+    "",
+    f"UNREACHABLE in campaign mode (no campaign flag, not in manifest): {len(unreachable)}",
+    *[f"    {r['field']}" for r in unreachable],
+    "",
+    f"NEVER read anywhere under host/: {len(never_read)}",
+    *[f"    {r['field']}" for r in never_read],
+  ]
+  if matrix["manifest_keys_not_spec_fields"]:
+    lines += ["", "manifest keys that are NOT spec fields:", *[f"    {k}" for k in matrix["manifest_keys_not_spec_fields"]]]
+  return "\n".join(lines)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+    "--repo", type=Path, default=Path(__file__).resolve().parents[2],
+    help="aminx repo root to AST-parse (must match the importable aminx).",
+  )
+  parser.add_argument("--out", type=Path, default=None, help="Write full matrix JSON here.")
+  parser.add_argument("-v", "--verbose", action="store_true")
+  args = parser.parse_args()
+
+  logging.basicConfig(
+    level=logging.DEBUG if args.verbose else logging.INFO,
+    format="%(levelname)s %(name)s: %(message)s",
+  )
+
+  matrix = build_matrix(args.repo)
+  print(summarize(matrix))
+
+  if args.out:
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(matrix, indent=2, sort_keys=True))
+    logger.info("wrote matrix: %s", args.out)
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/benchmarks/bench_aminx_jax.py
+++ b/scripts/benchmarks/bench_aminx_jax.py
@@ -140,6 +140,17 @@ class _BenchmarkSpec:
     average_node_features = False  # No encoding fusion for Wave 1
 
 
+# make_inference_plan reads decode-relevant fields from spec.run_spec.sampling (260716, EPIC
+# #1541 P4); build_run_spec() handles any duck spec via getattr(spec, "field", default).
+def _attach_run_spec() -> None:
+    from aminx.run.spec import build_run_spec
+
+    _BenchmarkSpec.run_spec = build_run_spec(_BenchmarkSpec)
+
+
+_attach_run_spec()
+
+
 def _make_benchmark_spec_with_temperatures(temperature_list: list[float] | None = None) -> _BenchmarkSpec:
     """Create a benchmark spec with custom temperature list.
 

--- a/scripts/benchmarks/bench_dedup_hetero.py
+++ b/scripts/benchmarks/bench_dedup_hetero.py
@@ -331,6 +331,10 @@ def benchmark_aminx_dedup(
             'temperature': [1.0],
             'average_node_features': False,
         })()
+        # make_inference_plan reads decode-relevant fields from spec.run_spec.sampling
+        # (260716, EPIC #1541 P4); build_run_spec() handles any duck spec.
+        from aminx.run.spec import build_run_spec
+        spec.run_spec = build_run_spec(spec)
         plan = make_inference_plan(model, spec)
 
     # Get batch parameters
@@ -781,6 +785,10 @@ def main() -> int:
             'temperature': [1.0],
             'average_node_features': False,
         })()
+        # make_inference_plan reads decode-relevant fields from spec.run_spec.sampling
+        # (260716, EPIC #1541 P4); build_run_spec() handles any duck spec.
+        from aminx.run.spec import build_run_spec
+        spec.run_spec = build_run_spec(spec)
         plan = make_inference_plan(model, spec)
         logger.info("Model and plan loaded successfully")
     except Exception as e:

--- a/scripts/benchmarks/bench_inference_plan_latency.py
+++ b/scripts/benchmarks/bench_inference_plan_latency.py
@@ -75,6 +75,7 @@ def create_bundle_and_plan_from_real_structure(seq_len: int | None = None) -> tu
     from aminx.types.configs import InferenceConfig
     from aminx.host.plan import make_inference_plan
     from aminx.inference.bundle_builder import build_inference_bundle
+    from aminx.run.spec import build_run_spec
 
     # Load real structure from test fixture
     fixture_path = (
@@ -147,6 +148,9 @@ def create_bundle_and_plan_from_real_structure(seq_len: int | None = None) -> tu
         state_weights = None
         temperature = [1.0]
 
+    # make_inference_plan reads decode-relevant fields from spec.run_spec.sampling (260716,
+    # EPIC #1541 P4); build_run_spec() handles any duck spec via getattr(spec, "field", default).
+    DummySpec.run_spec = build_run_spec(DummySpec)
     spec = DummySpec()
     plan = make_inference_plan(model, spec)
 

--- a/scripts/benchmarks/bench_mixed_length.py
+++ b/scripts/benchmarks/bench_mixed_length.py
@@ -85,6 +85,17 @@ class _BenchmarkSpec:
     average_node_features = False
 
 
+# make_inference_plan reads decode-relevant fields from spec.run_spec.sampling (260716, EPIC
+# #1541 P4); build_run_spec() handles any duck spec via getattr(spec, "field", default).
+def _attach_run_spec() -> None:
+    from aminx.run.spec import build_run_spec
+
+    _BenchmarkSpec.run_spec = build_run_spec(_BenchmarkSpec)
+
+
+_attach_run_spec()
+
+
 def _make_benchmark_spec_with_temperatures(temperature_list: list[float] | None = None) -> _BenchmarkSpec:
     """Create a benchmark spec with custom temperature list."""
     spec = _BenchmarkSpec()

--- a/src/aminx/cli.py
+++ b/src/aminx/cli.py
@@ -1651,8 +1651,10 @@ def campaign_plan(
     _OPT(
       "--fixed-arm",
       help=(
-        "Arm LABEL=PATH, e.g. catalytic_triad=masks/triad.npy. PATH holds a 1-D canonical "
-        "fixed_mask. Repeatable; each arm is its own row-set. Omit to fix nothing."
+        "Arm LABEL=DECLARATION, e.g. catalytic_triad=H38|D73|C143 -- residue letter plus "
+        "0-based canonical index, pipe-separated. The letters set fixed_tokens, so the arm "
+        "states WHAT to hold, not just where. A path to a 1-D .npy mask also works for large "
+        "sets. Repeatable; each arm is its own row-set. Omit to fix nothing."
       ),
     ),
   ] = None,
@@ -1891,8 +1893,10 @@ def campaign_ramp_plan(
     _OPT(
       "--fixed-arm",
       help=(
-        "Arm LABEL=PATH, e.g. catalytic_triad=masks/triad.npy. PATH holds a 1-D canonical "
-        "fixed_mask. Repeatable; each arm is its own row-set. Omit to fix nothing."
+        "Arm LABEL=DECLARATION, e.g. catalytic_triad=H38|D73|C143 -- residue letter plus "
+        "0-based canonical index, pipe-separated. The letters set fixed_tokens, so the arm "
+        "states WHAT to hold, not just where. A path to a 1-D .npy mask also works for large "
+        "sets. Repeatable; each arm is its own row-set. Omit to fix nothing."
       ),
     ),
   ] = None,

--- a/src/aminx/cli.py
+++ b/src/aminx/cli.py
@@ -801,7 +801,7 @@ def run_score(
     _OPT(help="Multi-state aggregation strategy"),
   ] = "arithmetic_mean",
 ) -> None:
-  """Score sequences against structure inputs (non-serializable fields: ar_mask, conformational_states, decoding_order_fn)."""
+  """Score sequences against structure inputs (non-serializable fields: conformational_states, decoding_order_fn)."""
   if not inputs:
     typer.echo("--inputs is required", err=True)
     raise typer.Exit(code=2)
@@ -980,7 +980,7 @@ def run_inspect(
     _OPT(help="Similarity metric: rmsd, tm-score, gdt_ts, gdt_ha, cosine"),
   ] = "rmsd",
 ) -> None:
-  """Inspect model encodings and features (non-serializable fields: ar_mask, conformational_states)."""
+  """Inspect model encodings and features (non-serializable fields: conformational_states)."""
   if not inputs:
     typer.echo("--inputs is required", err=True)
     raise typer.Exit(code=2)

--- a/src/aminx/cli.py
+++ b/src/aminx/cli.py
@@ -1646,10 +1646,16 @@ def campaign_plan(
     int,
     _OPT("--samples-chunk-size", help="Samples chunk size (required)"),
   ] = ...,  # ty: ignore[invalid-parameter-default]
-  fixed_policies: Annotated[
-    str,
-    _OPT("--fixed-policies", help="Comma-separated fixed policy names"),
-  ] = "catalytic_triad,active_site",
+  fixed_arm: Annotated[
+    list[str] | None,
+    _OPT(
+      "--fixed-arm",
+      help=(
+        "Arm LABEL=PATH, e.g. catalytic_triad=masks/triad.npy. PATH holds a 1-D canonical "
+        "fixed_mask. Repeatable; each arm is its own row-set. Omit to fix nothing."
+      ),
+    ),
+  ] = None,
   state_weight_profiles: Annotated[
     str,
     _OPT("--state-weight-profiles", help="Comma-separated state weight profile names"),
@@ -1695,6 +1701,7 @@ def campaign_plan(
   from aminx.host.campaign import (  # noqa: PLC0415
     SamplingSpecification,
     _parse_csv,
+    parse_fixed_arms,
     write_campaign_manifest,
   )
 
@@ -1713,7 +1720,7 @@ def campaign_plan(
     designs_per_library_type=designs_per_library_type,
     samples_chunk_size=samples_chunk_size,
     output_root=output_root,
-    fixed_policies=_parse_csv(fixed_policies),
+    fixed_arms=parse_fixed_arms(fixed_arm),
     state_weight_profiles=_parse_csv(state_weight_profiles),
   )
 
@@ -1879,10 +1886,16 @@ def campaign_ramp_plan(
     int,
     _OPT("--samples-chunk-size", help="Samples chunk size (required)"),
   ] = ...,  # ty: ignore[invalid-parameter-default]
-  fixed_policies: Annotated[
-    str,
-    _OPT("--fixed-policies", help="Comma-separated fixed policy names"),
-  ] = "catalytic_triad,active_site",
+  fixed_arm: Annotated[
+    list[str] | None,
+    _OPT(
+      "--fixed-arm",
+      help=(
+        "Arm LABEL=PATH, e.g. catalytic_triad=masks/triad.npy. PATH holds a 1-D canonical "
+        "fixed_mask. Repeatable; each arm is its own row-set. Omit to fix nothing."
+      ),
+    ),
+  ] = None,
   state_weight_profiles: Annotated[
     str,
     _OPT("--state-weight-profiles", help="Comma-separated state weight profile names"),
@@ -1901,6 +1914,7 @@ def campaign_ramp_plan(
     SamplingSpecification,
     _emit_json,
     _parse_csv,
+    parse_fixed_arms,
     _parse_int_csv,
     plan_scale_ramp,
   )
@@ -1917,7 +1931,7 @@ def campaign_ramp_plan(
     output_root=output_root,
     stage_designs_per_library_type=_parse_int_csv(stage_designs_per_library_type),
     samples_chunk_size=samples_chunk_size,
-    fixed_policies=_parse_csv(fixed_policies),
+    fixed_arms=parse_fixed_arms(fixed_arm),
     state_weight_profiles=_parse_csv(state_weight_profiles),
   )
   _emit_json(plan_payload, str(plan_path) if plan_path else None)

--- a/src/aminx/host/_sampling_helper.py
+++ b/src/aminx/host/_sampling_helper.py
@@ -449,6 +449,75 @@ def _broadcast_per_structure(
   raise ValueError(msg)
 
 
+def _token_name(token: int) -> str:
+  """Human-readable amino acid for an error message (never used for control flow)."""
+  from aminx.utils.aa_convert import MPNN_ALPHABET
+
+  return MPNN_ALPHABET[token] if 0 <= token < len(MPNN_ALPHABET) else str(token)
+
+
+def resolve_native_tokens(
+  batched_ensemble: Protein,
+  fixed_mask: Any,  # noqa: ANN401 -- ArrayLike; matches _broadcast_per_structure's convention
+  *,
+  allow_heterogeneous: bool = False,
+) -> np.ndarray:
+  """Resolve ``fixed_tokens`` from each structure's own native residues.
+
+  The override for "freeze these positions at whatever is already there", as opposed to passing
+  ``fixed_tokens`` explicitly. Returns an array shaped to ``batched_ensemble.aatype``.
+
+  Deliberately a function, not a ``SamplingSpecification`` field: a new spec field would be
+  silently dropped by ``host/campaign.py``'s hand-written manifest literal and become another
+  declared-but-never-delivered knob -- the exact bug class this guard exists to close.
+
+  **Divergence is refused, not resolved.** With multiple structures, "native" is only well
+  defined if they agree at every frozen position. For a product-of-experts bead the design is ONE
+  sequence, so a position whose native is Cys in one state and Ala in another (a real case: a
+  C151A catalytic mutant crystallised precisely because it was inactive) has no correct answer
+  this function can pick. Picking one silently is how a dead enzyme ships. Pass explicit
+  ``fixed_tokens`` to state the intent, or ``allow_heterogeneous=True`` to accept structure 0's
+  residue knowingly.
+
+  Args:
+    batched_ensemble: Batched structures; ``aatype`` supplies the native residues.
+    fixed_mask: Which positions are frozen. 1 = fixed.
+    allow_heterogeneous: Accept structure 0's residue where natives disagree.
+
+  Returns:
+    ``fixed_tokens``, suitable for ``SamplingSpecification(fixed_tokens=...)``.
+
+  Raises:
+    ValueError: Natives disagree at a frozen position and ``allow_heterogeneous`` is False.
+
+  """
+  aatype = np.asarray(batched_ensemble.aatype, dtype=np.int32)
+  if aatype.ndim == 1:
+    aatype = aatype[None, :]
+  mask = np.asarray(fixed_mask, dtype=np.float32)
+  if mask.ndim == 1:
+    mask = np.broadcast_to(mask[None, :], aatype.shape)
+
+  frozen = np.where(np.any(mask > 0, axis=0))[0]
+  if len(frozen) and aatype.shape[0] > 1 and not allow_heterogeneous:
+    divergent = [int(p) for p in frozen if len(np.unique(aatype[:, p])) > 1]
+    if divergent:
+      detail = "; ".join(
+        f"position {p}: " + ", ".join(f"structure {s}={_token_name(int(aatype[s, p]))}"
+                                      for s in range(aatype.shape[0]))
+        for p in divergent[:4]
+      )
+      msg = (
+        f"Cannot resolve native fixed_tokens: structures disagree at {len(divergent)} frozen "
+        f"position(s) -- {detail}. The design is a single sequence, so there is no native to "
+        f"pick. Either pass fixed_tokens explicitly to declare the intended identity, or set "
+        f"allow_heterogeneous=True to take structure 0's residue deliberately."
+      )
+      raise ValueError(msg)
+
+  return aatype.copy()
+
+
 def _prepare_fixed_controls(
   spec: SamplingSpecification,
   *,
@@ -491,10 +560,35 @@ def _prepare_fixed_controls(
       name="fixed_tokens",
     )
 
-    invalid_tokens = (fixed_tokens_np < 0) | (fixed_tokens_np >= AMINO_ACID_VOCAB_SIZE)
-    if np.any(invalid_tokens & (fixed_mask_np > 0)):
-      msg = f"fixed_tokens must be in [0, {AMINO_ACID_VOCAB_SIZE - 1}] at masked positions."
-      raise ValueError(msg)
+  # fixed_mask selects WHICH positions are frozen; fixed_tokens says TO WHAT. They are one
+  # decision, not two. Freezing without saying to what silently locks every frozen position to
+  # token 0 -- Alanine (utils/aa_convert.py's MPNN_ALPHABET) -- because decode does
+  # `final_token = where(is_group_fixed, fixed_tokens, sampled)` (decode/autoregressive.py:340).
+  # A caller "fixing the catalytic triad" would get a dead Ala/Ala/Ala enzyme, with valid-shaped
+  # output and no error. Refuse the ambiguity instead of resolving it to the most destructive
+  # possible default.
+  if np.any(np.asarray(fixed_mask_np) > 0) and spec.run_spec.sampling.fixed_tokens is None:
+    n_fixed = int(np.count_nonzero(np.asarray(fixed_mask_np)[0]))
+    msg = (
+      f"fixed_mask/fixed_positions freeze {n_fixed} position(s) but fixed_tokens is None, which "
+      f"would silently lock every frozen position to token 0 = '{_token_name(0)}' (Alanine) -- "
+      f"e.g. a 'fixed catalytic triad' would come back as Ala/Ala/Ala, a dead enzyme, with no "
+      f"error. Freezing a position and choosing its identity are one decision. Either:\n"
+      f"  - pass fixed_tokens explicitly (a 1-D array locks the same identity across all "
+      f"states -- the usual intent, e.g. a catalytic triad held at H/D/C everywhere); or\n"
+      f"  - call resolve_native_tokens(batched_ensemble, fixed_mask) to freeze each position at "
+      f"its own native residue."
+    )
+    raise ValueError(msg)
+
+  # Validity is checked AFTER the guard and OUTSIDE the `fixed_tokens is not None` branch it
+  # used to live in -- where it could never fire for the all-zeros default, which is exactly the
+  # case that needed catching. Token 0 is a legal amino acid, not a sentinel, so range-checking
+  # alone never would have caught it either.
+  invalid_tokens = (fixed_tokens_np < 0) | (fixed_tokens_np >= AMINO_ACID_VOCAB_SIZE)
+  if np.any(np.asarray(invalid_tokens) & (np.asarray(fixed_mask_np) > 0)):
+    msg = f"fixed_tokens must be in [0, {AMINO_ACID_VOCAB_SIZE - 1}] at masked positions."
+    raise ValueError(msg)
 
   if spec.run_spec.sampling.fixed_mask is not None:
     fm_broadcast = _broadcast_per_structure(

--- a/src/aminx/host/_sampling_helper.py
+++ b/src/aminx/host/_sampling_helper.py
@@ -449,11 +449,22 @@ def _broadcast_per_structure(
   raise ValueError(msg)
 
 
-def _token_name(token: int) -> str:
-  """Human-readable amino acid for an error message (never used for control flow)."""
-  from aminx.utils.aa_convert import MPNN_ALPHABET
+def _token_name(token: int, alphabet: str) -> str:
+  """Human-readable amino acid for an error message (never used for control flow).
 
-  return MPNN_ALPHABET[token] if 0 <= token < len(MPNN_ALPHABET) else str(token)
+  ``alphabet`` is REQUIRED and deliberately not defaulted. This helper is reachable from two
+  contexts in different alphabets -- native ``aatype`` (AF) and ``fixed_tokens`` (MPNN) --
+  and a default would silently pick one of them for both. The previous version defaulted to
+  MPNN and was called with AF ``aatype``, so a divergence at a His position reported "K".
+  An error message that misnames the residue is worse than no message: it sends the reader
+  hunting for a mutation that isn't there.
+
+  Args:
+    token: The integer token.
+    alphabet: The alphabet ``token`` is indexed in -- ``AF_ALPHABET`` or ``MPNN_ALPHABET``.
+
+  """
+  return alphabet[token] if 0 <= token < len(alphabet) else str(token)
 
 
 def resolve_native_tokens(
@@ -485,13 +496,28 @@ def resolve_native_tokens(
     allow_heterogeneous: Accept structure 0's residue where natives disagree.
 
   Returns:
-    ``fixed_tokens``, suitable for ``SamplingSpecification(fixed_tokens=...)``.
+    ``fixed_tokens`` in the **MPNN alphabet** (``ACDEFGHIKLMNPQRSTVWYX``), suitable for
+    ``SamplingSpecification(fixed_tokens=...)``. The conversion from ``aatype``'s AF ordering
+    happens here; callers must not convert again. Naming the alphabet is not decoration --
+    every bug this function has had, and every one found in the surrounding audit, traces to
+    a contract that said "integer labels" and left the ordering to be guessed.
 
   Raises:
     ValueError: Natives disagree at a frozen position and ``allow_heterogeneous`` is False.
 
   """
-  aatype = np.asarray(batched_ensemble.aatype, dtype=np.int32)
+  from aminx.utils.aa_convert import MPNN_ALPHABET, af_to_mpnn  # noqa: PLC0415
+
+  # Convert ONCE, here, so the whole function below is MPNN and there is no second
+  # convention to keep straight. `aatype` is AF (proxide is AF-native); `fixed_tokens` is
+  # substituted directly against model-sampled tokens at
+  # inference/decode/autoregressive.py:346, which are MPNN. Returning the raw array -- what
+  # this function did until now -- froze every position to a *different* residue than the
+  # caller's own structure: AF His(8) reads as MPNN Lys. A "fixed catalytic triad" would
+  # have come back H->K, D->E, C->F. Shipped in 026403d, the commit whose stated purpose was
+  # preventing a silently-wrong fixed identity, and hidden by test fixtures hand-written in
+  # the alphabet their author assumed.
+  aatype = np.asarray(af_to_mpnn(jnp.asarray(batched_ensemble.aatype)), dtype=np.int32)
   if aatype.ndim == 1:
     aatype = aatype[None, :]
   mask = np.asarray(fixed_mask, dtype=np.float32)
@@ -503,8 +529,11 @@ def resolve_native_tokens(
     divergent = [int(p) for p in frozen if len(np.unique(aatype[:, p])) > 1]
     if divergent:
       detail = "; ".join(
-        f"position {p}: " + ", ".join(f"structure {s}={_token_name(int(aatype[s, p]))}"
-                                      for s in range(aatype.shape[0]))
+        f"position {p}: "
+        + ", ".join(
+          f"structure {s}={_token_name(int(aatype[s, p]), MPNN_ALPHABET)}"
+          for s in range(aatype.shape[0])
+        )
         for p in divergent[:4]
       )
       msg = (
@@ -515,7 +544,7 @@ def resolve_native_tokens(
       )
       raise ValueError(msg)
 
-  return aatype.copy()
+  return aatype.copy()  # MPNN -- converted at the top of this function
 
 
 def _prepare_fixed_controls(
@@ -523,6 +552,8 @@ def _prepare_fixed_controls(
   *,
   batched_ensemble: Protein,
 ) -> tuple[jax.Array, jax.Array]:
+  from aminx.utils.aa_convert import MPNN_ALPHABET  # noqa: PLC0415
+
   batch_size, seq_len = batched_ensemble.coordinates.shape[:2]
 
   fixed_mask_np = np.zeros((batch_size, seq_len), dtype=np.float32)
@@ -562,8 +593,10 @@ def _prepare_fixed_controls(
 
   # fixed_mask selects WHICH positions are frozen; fixed_tokens says TO WHAT. They are one
   # decision, not two. Freezing without saying to what silently locks every frozen position to
-  # token 0 -- Alanine (utils/aa_convert.py's MPNN_ALPHABET) -- because decode does
-  # `final_token = where(is_group_fixed, fixed_tokens, sampled)` (decode/autoregressive.py:340).
+  # token 0 -- Alanine (index 0 in BOTH alphabets, so this one is unambiguous) -- because
+  # decode does `final_token = where(is_group_fixed, group_fixed_token, sampled)`
+  # (inference/decode/autoregressive.py:346; an earlier version of this comment cited
+  # decode/autoregressive.py:340, a path that does not exist).
   # A caller "fixing the catalytic triad" would get a dead Ala/Ala/Ala enzyme, with valid-shaped
   # output and no error. Refuse the ambiguity instead of resolving it to the most destructive
   # possible default.
@@ -571,7 +604,8 @@ def _prepare_fixed_controls(
     n_fixed = int(np.count_nonzero(np.asarray(fixed_mask_np)[0]))
     msg = (
       f"fixed_mask/fixed_positions freeze {n_fixed} position(s) but fixed_tokens is None, which "
-      f"would silently lock every frozen position to token 0 = '{_token_name(0)}' (Alanine) -- "
+      f"would silently lock every frozen position to token 0 = "
+      f"'{_token_name(0, MPNN_ALPHABET)}' (Alanine) -- "
       f"e.g. a 'fixed catalytic triad' would come back as Ala/Ala/Ala, a dead enzyme, with no "
       f"error. Freezing a position and choosing its identity are one decision. Either:\n"
       f"  - pass fixed_tokens explicitly (a 1-D array locks the same identity across all "

--- a/src/aminx/host/_sampling_helper.py
+++ b/src/aminx/host/_sampling_helper.py
@@ -449,6 +449,67 @@ def _broadcast_per_structure(
   raise ValueError(msg)
 
 
+def fixed_provenance_outputs(
+  spec: SamplingSpecification,
+  *,
+  seq_len: int,
+) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+  """The evidence that a residue was actually held fixed. Emit this beside the sequences.
+
+  Returns ``(arrays, attrs)`` to merge into the row's staged output.
+
+  **Why this exists.** ``fixed_mask`` reached the model and stopped there: it appeared nowhere
+  in ``io/`` or any sink, so after a run there was NO WAY to prove which positions had been
+  frozen. A campaign produced 882/882 rows, every done-marker valid, every content digest
+  intact -- and not one residue held fixed anywhere. The completion record was perfect and the
+  science was void, because completion and validity were the only two things nobody had
+  written down separately.
+
+  **Why not the done marker.** ``_write_done_marker`` carries the row hash, attempt id and
+  content digest -- integrity, not science. Worse, its digest is computed over the zarr tree
+  *before* the marker is written, so anything added there sits outside the very hash that
+  attests to it. This belongs inside the digested artifact, beside the data it describes.
+
+  **Why 1-D and not the broadcast (batch, L).** This records the DECLARATION -- "these
+  positions were requested frozen, at these identities" -- which is what a reader needs to
+  check the sequences against. ``_prepare_fixed_controls``' per-structure broadcast is an
+  implementation detail of one call.
+
+  ``n_fixed`` is an attr, not a derived read, so a reader can reject an unfixed row without
+  loading the mask -- and so "0 positions were fixed" is a value someone can SEE in the
+  metadata rather than a silence they have to notice.
+
+  Args:
+    spec: The row's spec, post-reconstruction.
+    seq_len: The parsed structure's padded length, used to emit an honest all-zero mask when
+      nothing is fixed -- an absent key and "nothing was fixed" must not look alike.
+
+  """
+  sampling = spec.run_spec.sampling
+  declared = sampling.fixed_mask
+  mask = (
+    np.zeros(seq_len, dtype=np.uint8)
+    if declared is None
+    else np.asarray(declared).reshape(-1)[:seq_len].astype(np.uint8)
+  )
+  arrays: dict[str, np.ndarray] = {"fixed_mask": mask}
+  attrs: dict[str, Any] = {"n_fixed": int(np.count_nonzero(mask))}
+
+  # Tokens only mean something where the mask selects, but emit the whole array: a reader
+  # comparing sequences against it needs the same indexing, and slicing here would invent a
+  # second convention to get wrong.
+  if sampling.fixed_tokens is not None:
+    arrays["fixed_tokens"] = np.asarray(sampling.fixed_tokens).reshape(-1)[:seq_len].astype(
+      np.int32,
+    )
+    # Name the alphabet AS DATA, not in a key name. The consumer-side bug this audit found was
+    # exactly a rename stripping an `_af` suffix and taking the convention with it: a rename
+    # cannot strip a value. fixed_tokens are MPNN by contract (decode substitutes them
+    # directly against MPNN-sampled tokens).
+    attrs["fixed_tokens_alphabet"] = "MPNN"
+  return arrays, attrs
+
+
 def _token_name(token: int, alphabet: str) -> str:
   """Human-readable amino acid for an error message (never used for control flow).
 

--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -29,6 +29,7 @@ from xtrax.run import (
 
 # campaign manifest functions are implemented in this module (see build_manifest_row et al.)
 from aminx.host.runner import sample
+from aminx.host.spec_partition import CAMPAIGN_OWNED_KEYS, campaign_sampling_spec_payload
 from aminx.run.specs import SamplingSpecification, pop_deprecated_spec_kwargs
 from aminx.sampling.multistate_poe import sample_multistate_poe_campaign_row
 from aminx.runtime import configure_multiprocessing
@@ -644,41 +645,25 @@ def plan_campaign_manifest(
               campaign_id=campaign_id,
               row_hash=row["manifest_row_hash"],
             )
-            row["sampling_spec"] = {
-              "inputs": _normalize_inputs(base_spec.inputs),
-              "model_family": spec_variant.model_family,
-              "model_weights": spec_variant.model_weights,
-              "model_version": spec_variant.model_version,
-              "checkpoint_id": spec_variant.checkpoint_id,
-              "model_local_path": (
-                str(spec_variant.model_local_path) if spec_variant.model_local_path else None
-              ),
-              "checkpoint_registry_path": (
-                str(spec_variant.checkpoint_registry_path)
-                if spec_variant.checkpoint_registry_path
-                else None
-              ),
-              "ligand_conditioning": ligand_on,
-              "sidechain_conditioning": sidechain_on,
-              "chain_id": spec_variant.chain_id,
-              "ligand_context_path": (
-                str(spec_variant.ligand_context_path)
-                if spec_variant.ligand_context_path
-                else None
-              ),
-              "temperature": list(spec_variant.temperature),
-              "backbone_noise": list(spec_variant.backbone_noise),
-              "batch_size": spec_variant.batch_size,
-              "samples_chunk_size": sample_count,
-              "campaign_mode": True,
-              "return_logits": False,
-              "grid_mode": True,
-              "job_id": row["job_id"],
-              "chunk_id": row["chunk_id"],
-              "sample_start": row["sample_start"],
-              "sample_count": row["sample_count"],
-              "output_h5_path": row["output_h5_path"],
-            }
+            # Built from dataclasses.fields(), NOT hand-listed. The hand-written 23-key literal
+            # this replaces drifted from an 88-field dataclass with nothing enforcing the sync,
+            # which is the single root cause of all twelve silently-dropped knobs -- including
+            # fixed_mask, i.e. no residue was ever actually held fixed in any produced design.
+            # spec_partition raises at import if any field is classified nowhere.
+            row["sampling_spec"] = campaign_sampling_spec_payload(
+              spec_variant,
+              campaign_owned={
+                "grid_mode": True,
+                # The planner owns chunking; the caller's samples_chunk_size is replaced, not
+                # dropped -- this row covers exactly sample_count designs.
+                "samples_chunk_size": sample_count,
+                "job_id": row["job_id"],
+                "chunk_id": row["chunk_id"],
+                "sample_start": row["sample_start"],
+                "sample_count": row["sample_count"],
+                "output_h5_path": row["output_h5_path"],
+              },
+            )
             rows.append(row)
           job_index += 1
 

--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 import threading
@@ -615,26 +616,105 @@ def _write_done_marker(
 _NO_ARM = "none"
 
 
-def _resolve_arm_mask(label: str, source: Any) -> Any:  # noqa: ANN401 -- ArrayLike | PathLike | None
-  """Turn an arm's mask SOURCE into a 1-D canonical mask array.
+# `H38|D73|C143` -- an IDENTITY letter and a canonical (0-based) index, per position.
+_ARM_RESIDUE_RE = re.compile(r"^([A-Z])(\d+)$")
 
-  Accepts an array (library callers) or a path to a ``.npy`` (every CLI surface -- an
-  84-residue mask is not typeable as a flag literal, and `_parse_csv` would shatter any comma
-  grammar anyway).
+
+def _parse_arm_declaration(label: str, text: str, *, length: int) -> tuple[np.ndarray, np.ndarray]:
+  """Parse ``H38|D73|C143`` into a (mask, tokens) pair.
+
+  **The letter is the point.** A bare position list would say *where* to freeze but not *what*
+  to, and the two are one decision -- freezing without stating the identity locks every frozen
+  position to token 0 (Alanine), which is why `_prepare_fixed_controls` refuses the pair. The
+  letters supply `fixed_tokens` directly, so nothing has to infer them: no structure parsing
+  at plan time, and no alphabet to get wrong.
+
+  It also makes the deliberate overrides *visible*. TEV's 1LVB is a C151A mutant -- the
+  crystal carries Ala where the catalysis needs Cys -- and `C143` says "hold Cys here" in the
+  declaration itself, where a reader sees it, rather than in a comment somewhere else.
+
+  And it is self-checking in a way a position list can never be. `CATALYTIC_PDB_IDS =
+  [135,181,183]` shipped in a consumer for weeks as "the catalytic triad"; those indices hold
+  **Ser/Ser/Pro**. Nothing about a bare `[127,173,175]` could have flagged that. `S127|S173|P175`
+  would have looked wrong to anyone who knows what a catalytic triad is -- and a worker holding
+  the structure can check the claim outright.
+
+  Pipe-separated, never comma: `_parse_csv` splits on comma and would shatter this into
+  separate bogus arms.
+
+  Args:
+    label: The arm's label, for error messages.
+    text: The declaration, e.g. ``"H38|D73|C143"``.
+    length: Mask length -- ``base_spec.max_length``, since the dataset op pads to it.
+
+  Returns:
+    ``(mask, tokens)``: a 1-D ``float32`` mask and a 1-D ``int32`` MPNN token array.
+
+  Raises:
+    ValueError: malformed entry, unknown residue letter, or an out-of-range index.
+
+  """
+  from aminx.utils.aa_convert import MPNN_ALPHABET  # noqa: PLC0415
+
+  mask = np.zeros(length, dtype=np.float32)
+  tokens = np.zeros(length, dtype=np.int32)
+  for entry in (e.strip() for e in text.split("|") if e.strip()):
+    match = _ARM_RESIDUE_RE.match(entry)
+    if match is None:
+      msg = (
+        f"fixed_arms[{label!r}]: {entry!r} is not a RESIDUE+POSITION like 'H38'. Declare the "
+        f"identity, not just the position -- freezing a position without saying what to hold "
+        f"it at locks it to Alanine. Example: catalytic_triad=H38|D73|C143"
+      )
+      raise ValueError(msg)
+    letter, index = match.group(1), int(match.group(2))
+    if letter not in MPNN_ALPHABET:
+      msg = f"fixed_arms[{label!r}]: {letter!r} in {entry!r} is not an amino acid letter."
+      raise ValueError(msg)
+    if not 0 <= index < length:
+      msg = (
+        f"fixed_arms[{label!r}]: position {index} in {entry!r} is outside [0, {length}). "
+        f"Positions are 0-based CANONICAL indices (the reference state's own numbering), not "
+        f"author/PDB numbering -- for TEV the catalytic triad His46/Asp81/Cys151 is "
+        f"[38, 73, 143], i.e. author number minus 8."
+      )
+      raise ValueError(msg)
+    mask[index] = 1.0
+    tokens[index] = MPNN_ALPHABET.index(letter)
+  if not np.any(mask):
+    msg = f"fixed_arms[{label!r}]: {text!r} declares no positions."
+    raise ValueError(msg)
+  return mask, tokens
+
+
+def _resolve_arm(
+  label: str,
+  source: Any,  # noqa: ANN401 -- str declaration | ArrayLike | PathLike | None
+  *,
+  length: int,
+) -> tuple[Any, Any]:
+  """Resolve an arm SOURCE into ``(mask, tokens)``. Tokens are None unless declared.
+
+  Three shapes, in the order a caller is likely to reach for them:
+    - ``"H38|D73|C143"`` -- the inline declaration. No file needed for the common case, which
+      is the whole point: materialising a `.npy` to say "hold three residues" is friction.
+    - a path to a ``.npy`` -- the escape hatch for large sets (an 84-residue active-site shell
+      is not worth typing). Carries a mask only, so `fixed_tokens` must come from elsewhere.
+    - an array -- library callers who already have one.
 
   Raises:
     ValueError: the mask is not 1-D. Per-state `(S, L)` masks are refused HERE, at the
-      declaration, rather than at `multistate_poe.py`'s much later guard -- same verdict,
-      but the error arrives while the caller still has the context to fix it.
+      declaration, rather than at `multistate_poe.py`'s much later guard -- same verdict, but
+      the error arrives while the caller still has the context to fix it.
 
   """
   if source is None:
-    return None
+    return None, None
 
-  mask = source
-  if isinstance(source, (str, Path)):
-    mask = np.load(Path(source))
+  if isinstance(source, str) and not source.endswith(".npy"):
+    return _parse_arm_declaration(label, source, length=length)
 
+  mask = np.load(Path(source)) if isinstance(source, (str, Path)) else source
   mask = np.asarray(mask)
   if mask.ndim != 1:
     msg = (
@@ -646,7 +726,7 @@ def _resolve_arm_mask(label: str, source: Any) -> Any:  # noqa: ANN401 -- ArrayL
       f"instead."
     )
     raise ValueError(msg)
-  return mask
+  return mask, None
 
 
 def plan_campaign_manifest(
@@ -719,13 +799,20 @@ def plan_campaign_manifest(
   # validate_manifest_rows' existing emptiness check still means something, and keeps
   # "nothing fixed" a first-class, nameable arm rather than an absence.
   arms: Mapping[str, Any] = fixed_arms if fixed_arms is not None else {_NO_ARM: None}
-  resolved_arms = {label: _resolve_arm_mask(label, src) for label, src in arms.items()}
+  # Length comes from base_spec.max_length: the dataset op pads to it (prep.py:117), and
+  # _prepare_fixed_controls sizes the mask against the PARSED structure. The planner parses
+  # nothing, so this is the only length it can honestly use -- and the campaign CLIs expose
+  # no --max-length, so it is the one every campaign actually runs.
+  arm_length = base_spec.max_length or 512
+  resolved_arms = {
+    label: _resolve_arm(label, src, length=arm_length) for label, src in arms.items()
+  }
 
   output_root_path = Path(output_root)
   rows: list[dict[str, Any]] = []
   job_index = 0
 
-  for fixed_policy, arm_mask in resolved_arms.items():
+  for fixed_policy, (arm_mask, arm_tokens) in resolved_arms.items():
     for state_weight_profile in state_weight_profiles:
       for ligand_on in (False, True):
         for sidechain_on in (False, True):
@@ -749,6 +836,11 @@ def plan_campaign_manifest(
             # mask directly (the pre-existing route, and the one tev_design uses today via
             # its manifest patch) keeps working untouched.
             fixed_mask=arm_mask if arm_mask is not None else base_spec.fixed_mask,
+            # The declaration's letters ARE the tokens -- H38 says "hold His here". Nothing
+            # has to infer them, so there is no alphabet to get wrong and no structure to
+            # parse at plan time. Falls back to the caller's own tokens for the .npy/array
+            # shapes, which carry a mask only.
+            fixed_tokens=arm_tokens if arm_tokens is not None else base_spec.fixed_tokens,
           )
           for chunk_index, sample_start in enumerate(
             range(0, designs_per_library_type, samples_chunk_size),
@@ -1467,7 +1559,11 @@ def _parse_csv(value: str) -> tuple[str, ...]:
 
 
 def parse_fixed_arms(values: Sequence[str] | None) -> dict[str, str] | None:
-  """Parse repeated ``label=path.npy`` into a ``fixed_arms`` mapping.
+  """Parse repeated ``label=declaration`` into a ``fixed_arms`` mapping.
+
+  The value is passed through untouched -- ``_resolve_arm`` decides whether it is an inline
+  declaration (``H38|D73|C143``) or a ``.npy`` path. This function only splits label from
+  value, so there is exactly one place that knows the arm grammar.
 
   A REPEATED flag, deliberately not CSV. ``_parse_csv`` splits on comma, so any comma-bearing
   grammar (``triad=H38,D73,C143``) would be shattered into bogus separate cells -- and
@@ -1475,10 +1571,9 @@ def parse_fixed_arms(values: Sequence[str] | None) -> dict[str, str] | None:
   idiom as ``cli._parse_tied_positions``: repeat the flag, split once on a non-comma
   separator.
 
-  The value is a PATH, not literals. An arm's mask can be 84 of 214 positions; that is not
-  typeable as a flag, and inlining positions would put the referent somewhere the file cannot
-  check. A ``.npy`` also means the caller's own tooling produced it from their own bundle --
-  which is the point, since aminx cannot know any protein's catalytic triad.
+  Inline is the common case and needs no file: requiring a caller to materialise a ``.npy``
+  to say "hold three residues" is friction with nothing to show for it. A path stays supported
+  for large sets (an 84-residue active-site shell is not worth typing).
 
   Returns None for no flags, so the caller gets the honest "fix nothing" default rather than
   an empty mapping (which `plan_campaign_manifest` rejects as a contradiction).
@@ -1495,8 +1590,9 @@ def parse_fixed_arms(values: Sequence[str] | None) -> dict[str, str] | None:
     label, path = label.strip(), path.strip()
     if not sep or not label or not path:
       msg = (
-        f"--fixed-arm expects LABEL=PATH (e.g. --fixed-arm catalytic_triad=masks/triad.npy), "
-        f"got {raw!r}. Repeat the flag for additional arms; each becomes its own row-set."
+        f"--fixed-arm expects LABEL=DECLARATION (e.g. --fixed-arm "
+        f"catalytic_triad=H38|D73|C143), got {raw!r}. Repeat the flag for additional arms; "
+        f"each becomes its own row-set. A .npy mask path also works for large sets."
       )
       raise ValueError(msg)
     if label in arms:
@@ -1538,7 +1634,10 @@ def _add_plan_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
   # label and never reached the model. Absent => fix nothing.
   parser.add_argument(
     "--fixed-arm", action="append", default=None, metavar="LABEL=PATH",
-    help="Arm label -> path to a 1-D canonical fixed_mask .npy. Repeatable.",
+    help=(
+      "Arm LABEL=DECLARATION, e.g. catalytic_triad=H38|D73|C143 (residue letter + 0-based "
+      "canonical index). A .npy mask path also works. Repeatable."
+    ),
   )
   parser.add_argument("--state-weight-profiles", default="equal")
 
@@ -1607,7 +1706,10 @@ def _add_ramp_plan_parser(subparsers: argparse._SubParsersAction[argparse.Argume
   # label and never reached the model. Absent => fix nothing.
   parser.add_argument(
     "--fixed-arm", action="append", default=None, metavar="LABEL=PATH",
-    help="Arm label -> path to a 1-D canonical fixed_mask .npy. Repeatable.",
+    help=(
+      "Arm LABEL=DECLARATION, e.g. catalytic_triad=H38|D73|C143 (residue letter + 0-based "
+      "canonical index). A .npy mask path also works. Repeatable."
+    ),
   )
   parser.add_argument("--state-weight-profiles", default="equal")
   parser.add_argument("--plan-path", default=None)

--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -12,13 +12,14 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from itertools import pairwise
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 from xtrax.run import (
   canonical_json_bytes,
   fsync_directory,
@@ -157,18 +158,35 @@ def load_manifest(manifest_path: str | Path) -> dict[str, Any]:
   return payload
 
 
-def validate_manifest_rows(
-  rows: list[dict[str, Any]],
-  *,
-  required_fixed_policies: tuple[str, ...] | None = None,
-) -> None:
+def validate_manifest_rows(rows: list[dict[str, Any]]) -> None:
   """Validate manifest rows for uniqueness and required fields.
 
   Enforces:
   - All rows have a non-empty manifest_row_hash
   - No duplicate manifest_row_hash (zero_lineage_collisions gate invariant)
   - All rows have non-empty checkpoint_id, fixed_policy, state_weight_profile
-  - All required_fixed_policies are represented in at least one row
+  - A row naming a real arm (fixed_policy != "none") actually CARRIES a mask in its
+    sampling_spec -- see below
+
+  **`required_fixed_policies` is GONE, deliberately.** It did this::
+
+      policies_seen = {row["fixed_policy"] for row in rows}
+      missing = set(required_fixed_policies) - policies_seen
+
+  and `plan_campaign_manifest` called it with the very tuple its own row loop had just
+  consumed. It compared the planner's output against the planner's input: it could not fail.
+  It "validated" that a string label was present -- nothing about whether a residue was
+  fixed. It was green for the entire life of the decorative-policy bug, across 882/882 beads
+  that held nothing fixed. Fixing the comparison would not help; a gate whose two sides come
+  from the same source is theatre wherever you point it.
+
+  What replaces it checks a row against ITSELF: if you say you have an arm, the mask must be
+  in your own sampling_spec. That is a claim the planner can actually get wrong.
+
+  **This is not the real gate.** The final artifact is not this one: consumers patch the
+  planned manifest afterwards and write it with a raw `json.dumps`, so nothing here survives
+  to the worker as a guarantee. The binding check is the two-armed differential at sampling
+  time (masked vs unmasked must DIFFER). Do not mistake this for proof.
 
   Raises ValueError on any violation.
   """
@@ -206,12 +224,21 @@ def validate_manifest_rows(
     if state_weight_profile is None or not str(state_weight_profile).strip():
       msg = f"Row {row_hash} has empty or missing state_weight_profile"
       raise ValueError(msg)
-  if required_fixed_policies:
-    policies_seen = {str(row.get("fixed_policy", "")).strip() for row in rows}
-    missing = set(required_fixed_policies) - policies_seen
-    if missing:
-      msg = f"Required fixed policies not found in rows: {sorted(missing)}"
-      raise ValueError(msg)
+    # A row that names an arm must CARRY that arm's mask. Checks the row against itself --
+    # unlike the deleted `required_fixed_policies` arm, which checked the planner's output
+    # against the planner's own input and therefore could never fail.
+    if str(fixed_policy).strip() != _NO_ARM:
+      spec_payload = row.get("sampling_spec") or {}
+      arm_mask = spec_payload.get("fixed_mask")
+      if arm_mask is None or not np.any(np.asarray(arm_mask)):
+        msg = (
+          f"Row {row_hash} declares fixed_policy={fixed_policy!r} but its sampling_spec "
+          f"carries no fixed_mask with any set position. The worker reconstructs its spec "
+          f"from sampling_spec alone, so this row would design every residue while claiming "
+          f"otherwise -- the exact failure that voided an 882-bead library. Use "
+          f"fixed_policy={_NO_ARM!r} if nothing should be fixed."
+        )
+        raise ValueError(msg)
 
 
 def write_manifest(
@@ -582,6 +609,46 @@ def _write_done_marker(
   fsync_directory(marker_path.parent)
 
 
+# The label for "nothing is fixed". A first-class arm, not an absence -- so the row's
+# fixed_policy field stays non-empty and "design everything" is something you can name, grid
+# on, and see in a manifest diff.
+_NO_ARM = "none"
+
+
+def _resolve_arm_mask(label: str, source: Any) -> Any:  # noqa: ANN401 -- ArrayLike | PathLike | None
+  """Turn an arm's mask SOURCE into a 1-D canonical mask array.
+
+  Accepts an array (library callers) or a path to a ``.npy`` (every CLI surface -- an
+  84-residue mask is not typeable as a flag literal, and `_parse_csv` would shatter any comma
+  grammar anyway).
+
+  Raises:
+    ValueError: the mask is not 1-D. Per-state `(S, L)` masks are refused HERE, at the
+      declaration, rather than at `multistate_poe.py`'s much later guard -- same verdict,
+      but the error arrives while the caller still has the context to fix it.
+
+  """
+  if source is None:
+    return None
+
+  mask = source
+  if isinstance(source, (str, Path)):
+    mask = np.load(Path(source))
+
+  mask = np.asarray(mask)
+  if mask.ndim != 1:
+    msg = (
+      f"fixed_arms[{label!r}] has shape {mask.shape}; a fixed_mask must be 1-D (L,) in the "
+      f"canonical reference frame. Per-state (S, L) masks are not supported: one sequence is "
+      f"sampled, so a position is either designed or it is not (decode broadcasts the mask "
+      f"over the group axis, and sampling/multistate_poe.py refuses a per-state mask "
+      f"outright). Cross-state index shifts are what state_position_map resolves -- set that "
+      f"instead."
+    )
+    raise ValueError(msg)
+  return mask
+
+
 def plan_campaign_manifest(
   *,
   base_spec: SamplingSpecification,
@@ -589,7 +656,7 @@ def plan_campaign_manifest(
   designs_per_library_type: int,
   samples_chunk_size: int,
   output_root: str | Path,
-  fixed_policies: tuple[str, ...] = ("catalytic_triad", "active_site"),
+  fixed_arms: Mapping[str, Any] | None = None,
   state_weight_profiles: tuple[str, ...] = ("equal",),
   planner_version: str = "planner_v1",
   dataset_fingerprint: str = "unknown",
@@ -597,7 +664,37 @@ def plan_campaign_manifest(
   git_sha: str = "unknown",
   config_hash: str = "unknown",
 ) -> list[dict[str, Any]]:
-  """Plan campaign rows for all library/fixed-policy/profile combinations."""
+  """Plan campaign rows for all library/fixed-arm/profile combinations.
+
+  Args:
+    fixed_arms: Maps an arm LABEL to the **1-D canonical fixed_mask** it means, or to a path
+      to a ``.npy`` holding one. ``None`` (the default) means fix nothing -- every residue
+      designable -- which is the only default aminx can honestly ship, since it cannot know
+      any particular protein's catalytic triad. Each arm becomes its own row-set.
+
+      **The arm carries its own referent, and that is the whole point.** This replaces
+      ``fixed_policies: tuple[str, ...]``, which took bare NAMES like ``"catalytic_triad"``
+      that aminx had no way to resolve -- positions are protein-specific and live in the
+      caller's own bundle. So the name was written into the manifest row as a label and
+      never into the spec, the worker (which reads only ``row["sampling_spec"]``) never saw
+      it, and **no residue was ever held fixed in any produced design**: 882/882 beads of a
+      real library, silently violating a locked preregistration. A resolver callback is not
+      an alternative -- callables cannot cross the manifest's JSON boundary, and
+      ``spec_partition._assert_no_callable_knobs`` refuses them.
+
+      **Masks are 1-D `(L,)` in the canonical reference frame, never per-state `(S, L)`.**
+      ``types/bundles.py`` types ``fixed_mask`` as ``Float[Array, L]`` while
+      ``state_position_map`` beside it is ``"S L"``; ``sampling/multistate_poe.py`` RAISES on
+      a genuinely per-state mask; decode broadcasts the mask over the *group* axis because
+      one sequence is sampled and a position is either designed or it is not. Cross-state
+      index shifts are exactly what ``state_position_map`` exists to resolve.
+
+  Raises:
+    ValueError: ``fixed_arms`` is an empty mapping (states "here are my arms", then supplies
+      none -- a contradiction, and silently reading it as "design everything" is how the old
+      zero-rows bug read), or a mask is not 1-D.
+
+  """
   if designs_per_library_type <= 0:
     msg = "designs_per_library_type must be positive."
     raise ValueError(msg)
@@ -605,11 +702,30 @@ def plan_campaign_manifest(
     msg = "samples_chunk_size must be positive."
     raise ValueError(msg)
 
+  # `{}` is a contradiction, not a default. Distinct from `None` ("I did not ask for fixing"),
+  # which yields the no-arm row-set below. The predecessor silently returned ZERO rows for an
+  # empty policy set: the policy loop was outermost, so the body never ran, and
+  # validate_manifest_rows then skipped every check because its own guard is
+  # `if required_fixed_policies:`. An empty manifest is not a plan.
+  if fixed_arms is not None and not fixed_arms:
+    msg = (
+      "fixed_arms is an empty mapping, which asks for arms and then supplies none. Pass "
+      "fixed_arms=None to design every residue (the default), or supply at least one "
+      "label -> 1-D canonical fixed_mask."
+    )
+    raise ValueError(msg)
+
+  # The no-arm sentinel. `_NO_ARM` keeps the row's fixed_policy field non-empty so
+  # validate_manifest_rows' existing emptiness check still means something, and keeps
+  # "nothing fixed" a first-class, nameable arm rather than an absence.
+  arms: Mapping[str, Any] = fixed_arms if fixed_arms is not None else {_NO_ARM: None}
+  resolved_arms = {label: _resolve_arm_mask(label, src) for label, src in arms.items()}
+
   output_root_path = Path(output_root)
   rows: list[dict[str, Any]] = []
   job_index = 0
 
-  for fixed_policy in fixed_policies:
+  for fixed_policy, arm_mask in resolved_arms.items():
     for state_weight_profile in state_weight_profiles:
       for ligand_on in (False, True):
         for sidechain_on in (False, True):
@@ -620,6 +736,19 @@ def plan_campaign_manifest(
             return_logits=False,
             ligand_conditioning=ligand_on,
             sidechain_conditioning=sidechain_on,
+            # THE LINE WHOSE ABSENCE WAS THE ENTIRE BUG.
+            #
+            # The arm's mask has to land on the SPEC, because `sampling_spec` is the only
+            # thing the worker reconstructs from (run_manifest_row). Previously the loop
+            # variable reached `build_manifest_row(..., fixed_policy=...)` -- the row's
+            # LABEL -- and stopped there, so `campaign_sampling_spec_payload(spec_variant)`
+            # below could not see it, and the model was never told to hold anything. Every
+            # downstream check then inspected the label and was satisfied.
+            #
+            # `base_spec.fixed_mask` wins when no arm supplies one, so a caller who sets the
+            # mask directly (the pre-existing route, and the one tev_design uses today via
+            # its manifest patch) keeps working untouched.
+            fixed_mask=arm_mask if arm_mask is not None else base_spec.fixed_mask,
           )
           for chunk_index, sample_start in enumerate(
             range(0, designs_per_library_type, samples_chunk_size),
@@ -668,7 +797,7 @@ def plan_campaign_manifest(
             rows.append(row)
           job_index += 1
 
-  validate_manifest_rows(rows, required_fixed_policies=fixed_policies)
+  validate_manifest_rows(rows)
   return rows
 
 
@@ -680,7 +809,7 @@ def write_campaign_manifest(
   designs_per_library_type: int,
   samples_chunk_size: int,
   output_root: str | Path,
-  fixed_policies: tuple[str, ...] = ("catalytic_triad", "active_site"),
+  fixed_arms: Mapping[str, Any] | None = None,
   state_weight_profiles: tuple[str, ...] = ("equal",),
   planner_version: str = "planner_v1",
   dataset_fingerprint: str = "unknown",
@@ -688,14 +817,14 @@ def write_campaign_manifest(
   git_sha: str = "unknown",
   config_hash: str = "unknown",
 ) -> Path:
-  """Plan rows and write campaign manifest JSON."""
+  """Plan rows and write campaign manifest JSON. See `plan_campaign_manifest` for fixed_arms."""
   rows = plan_campaign_manifest(
     base_spec=base_spec,
     campaign_id=campaign_id,
     designs_per_library_type=designs_per_library_type,
     samples_chunk_size=samples_chunk_size,
     output_root=output_root,
-    fixed_policies=fixed_policies,
+    fixed_arms=fixed_arms,
     state_weight_profiles=state_weight_profiles,
     planner_version=planner_version,
     dataset_fingerprint=dataset_fingerprint,
@@ -1012,7 +1141,7 @@ def plan_scale_ramp(
   output_root: str | Path,
   stage_designs_per_library_type: Sequence[int],
   samples_chunk_size: int,
-  fixed_policies: tuple[str, ...] = ("catalytic_triad", "active_site"),
+  fixed_arms: Mapping[str, Any] | None = None,
   state_weight_profiles: tuple[str, ...] = ("equal",),
   planner_version: str = "planner_v1",
   dataset_fingerprint: str = "unknown",
@@ -1049,7 +1178,7 @@ def plan_scale_ramp(
       designs_per_library_type=designs_per_library_type,
       samples_chunk_size=samples_chunk_size,
       output_root=stage_output_root,
-      fixed_policies=fixed_policies,
+      fixed_arms=fixed_arms,
       state_weight_profiles=state_weight_profiles,
       planner_version=planner_version,
       dataset_fingerprint=dataset_fingerprint,
@@ -1337,6 +1466,46 @@ def _parse_csv(value: str) -> tuple[str, ...]:
   return tuple(item.strip() for item in value.split(",") if item.strip())
 
 
+def parse_fixed_arms(values: Sequence[str] | None) -> dict[str, str] | None:
+  """Parse repeated ``label=path.npy`` into a ``fixed_arms`` mapping.
+
+  A REPEATED flag, deliberately not CSV. ``_parse_csv`` splits on comma, so any comma-bearing
+  grammar (``triad=H38,D73,C143``) would be shattered into bogus separate cells -- and
+  ``validate_manifest_rows`` would then compare the wreckage against itself and pass. Same
+  idiom as ``cli._parse_tied_positions``: repeat the flag, split once on a non-comma
+  separator.
+
+  The value is a PATH, not literals. An arm's mask can be 84 of 214 positions; that is not
+  typeable as a flag, and inlining positions would put the referent somewhere the file cannot
+  check. A ``.npy`` also means the caller's own tooling produced it from their own bundle --
+  which is the point, since aminx cannot know any protein's catalytic triad.
+
+  Returns None for no flags, so the caller gets the honest "fix nothing" default rather than
+  an empty mapping (which `plan_campaign_manifest` rejects as a contradiction).
+
+  Raises:
+    ValueError: an entry has no ``=``, an empty label, or an empty path.
+
+  """
+  if not values:
+    return None
+  arms: dict[str, str] = {}
+  for raw in values:
+    label, sep, path = raw.partition("=")
+    label, path = label.strip(), path.strip()
+    if not sep or not label or not path:
+      msg = (
+        f"--fixed-arm expects LABEL=PATH (e.g. --fixed-arm catalytic_triad=masks/triad.npy), "
+        f"got {raw!r}. Repeat the flag for additional arms; each becomes its own row-set."
+      )
+      raise ValueError(msg)
+    if label in arms:
+      msg = f"--fixed-arm {label!r} given twice; arm labels must be unique."
+      raise ValueError(msg)
+    arms[label] = path
+  return arms
+
+
 def _parse_int_csv(value: str) -> tuple[int, ...]:
   parsed: list[int] = []
   for item in value.split(","):
@@ -1364,7 +1533,13 @@ def _add_plan_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
   parser.add_argument("--output-root", required=True)
   parser.add_argument("--designs-per-library-type", type=int, required=True)
   parser.add_argument("--samples-chunk-size", type=int, required=True)
-  parser.add_argument("--fixed-policies", default="catalytic_triad,active_site")
+  # Repeatable LABEL=PATH, not a CSV of bare names. A bare name was unresolvable --
+  # aminx cannot know any protein's catalytic triad -- so it was written to the row as a
+  # label and never reached the model. Absent => fix nothing.
+  parser.add_argument(
+    "--fixed-arm", action="append", default=None, metavar="LABEL=PATH",
+    help="Arm label -> path to a 1-D canonical fixed_mask .npy. Repeatable.",
+  )
   parser.add_argument("--state-weight-profiles", default="equal")
 
 
@@ -1427,7 +1602,13 @@ def _add_ramp_plan_parser(subparsers: argparse._SubParsersAction[argparse.Argume
   parser.add_argument("--output-root", required=True)
   parser.add_argument("--stage-designs-per-library-type", required=True)
   parser.add_argument("--samples-chunk-size", type=int, required=True)
-  parser.add_argument("--fixed-policies", default="catalytic_triad,active_site")
+  # Repeatable LABEL=PATH, not a CSV of bare names. A bare name was unresolvable --
+  # aminx cannot know any protein's catalytic triad -- so it was written to the row as a
+  # label and never reached the model. Absent => fix nothing.
+  parser.add_argument(
+    "--fixed-arm", action="append", default=None, metavar="LABEL=PATH",
+    help="Arm label -> path to a 1-D canonical fixed_mask .npy. Repeatable.",
+  )
   parser.add_argument("--state-weight-profiles", default="equal")
   parser.add_argument("--plan-path", default=None)
 
@@ -1455,7 +1636,7 @@ def _handle_plan_command(args: argparse.Namespace) -> int:
     designs_per_library_type=args.designs_per_library_type,
     samples_chunk_size=args.samples_chunk_size,
     output_root=args.output_root,
-    fixed_policies=_parse_csv(args.fixed_policies),
+    fixed_arms=parse_fixed_arms(args.fixed_arm),
     state_weight_profiles=_parse_csv(args.state_weight_profiles),
   )
   return 0
@@ -1508,7 +1689,7 @@ def _handle_ramp_plan_command(args: argparse.Namespace) -> int:
     output_root=args.output_root,
     stage_designs_per_library_type=_parse_int_csv(args.stage_designs_per_library_type),
     samples_chunk_size=args.samples_chunk_size,
-    fixed_policies=_parse_csv(args.fixed_policies),
+    fixed_arms=parse_fixed_arms(args.fixed_arm),
     state_weight_profiles=_parse_csv(args.state_weight_profiles),
   )
   _emit_json(plan_payload, args.plan_path)

--- a/src/aminx/host/campaign.py
+++ b/src/aminx/host/campaign.py
@@ -30,6 +30,7 @@ from xtrax.run import (
 # campaign manifest functions are implemented in this module (see build_manifest_row et al.)
 from aminx.host.runner import sample
 from aminx.host.spec_partition import CAMPAIGN_OWNED_KEYS, campaign_sampling_spec_payload
+from aminx.run.spec_json import _coerce_field_value
 from aminx.run.specs import SamplingSpecification, pop_deprecated_spec_kwargs
 from aminx.sampling.multistate_poe import sample_multistate_poe_campaign_row
 from aminx.runtime import configure_multiprocessing
@@ -838,6 +839,22 @@ def run_manifest_row(  # noqa: PLR0915
     worker_payload = dict(sampling_spec_payload)
     worker_payload["output_h5_path"] = str(partial_path)
     pop_deprecated_spec_kwargs(worker_payload)
+    # Coerce JSON scalars back to their spec types (lists -> ndarray for the array knobs,
+    # list -> tuple for temperature) using spec_json's whitelist, which names exactly these
+    # fields and exists for exactly this. Before the field-driven manifest write, array knobs
+    # were dropped entirely and no worker ever saw them; now they arrive, and they arrive as
+    # plain lists. Most consumers wrap defensively (_sample_batch does
+    # jnp.asarray(spec...bias)), but relying on EVERY consumer to be careful is the posture
+    # this audit exists to end -- restore the type at the boundary instead.
+    #
+    # Coercion is a VALUE transform, so strict unknown-key rejection is unaffected: an unknown
+    # key still reaches the constructor and raises TypeError. That strictness is why this path
+    # uses the plain constructor rather than run_specification_from_json_dict, which would
+    # silently ignore unknown keys.
+    worker_payload = {
+      key: _coerce_field_value(SamplingSpecification, key, value)
+      for key, value in worker_payload.items()
+    }
     sampling_spec = SamplingSpecification(**worker_payload)
     # Genuine multi-state PoE rows (len(inputs) > 1) route to
     # sample_multistate_poe_campaign_row instead of sample() -- sample()'s real dispatcher

--- a/src/aminx/host/plan.py
+++ b/src/aminx/host/plan.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import equinox as eqx
 import jax
@@ -729,7 +729,58 @@ def _run_packer_vmap(packer_model, keys, packer_bundle, config_params):
   return jax.vmap(run_single, in_axes=(0, packer_in_axes))(keys, packer_bundle)
 
 
-def make_inference_plan(model: ModelProtocol, spec: Any, packer: Any = None) -> InferencePlan:
+def resolve_decode_mode(
+  run_spec: Any,
+  *,
+  purpose: Literal["sample", "score"],
+) -> Any:
+  """Resolve which DecodeMode to build from a RunSpec -- the ONE place this decision is made.
+
+  Both `host.plan.make_inference_plan` (the single-structure/scoring path) and
+  `sampling.multistate_poe.sample_multistate_poe_bead` (the genuine multi-state PoE path) call
+  this instead of each independently deciding, which is how aminx#110 happened: the two paths
+  disagreed about which decode class to build (and therefore which conditioning fields --
+  fixed_mask, temperature, num_samples -- had any effect at all) with nothing forcing agreement.
+
+  `purpose` distinguishes "produce new sequences" from "evaluate a given sequence" --
+  `run_spec.sampling.sampling_strategy` alone cannot do this: a sampling call at its default
+  "temperature" strategy and a scoring call share the identical (non-"straight_through") value,
+  and were structurally indistinguishable before this parameter existed. That indistinguishability
+  is the literal root cause of aminx#110 -- `make_inference_plan` always built `ConditionalDecode`
+  (a single teacher-forced pass, correct for scoring, silently wrong for sampling) because nothing
+  told it which of the two callers it was serving.
+
+  Parameters
+  ----------
+  run_spec : RunSpec
+      The resolved `spec.run_spec` (not the flat spec) -- `sampling_strategy` lives at
+      `run_spec.sampling.sampling_strategy` (added 260716, EPIC #1541 P4).
+  purpose : {"sample", "score"}
+      "sample" -- caller wants new sequences (host.runner.sample(), the PoE campaign path).
+      "score" -- caller wants to evaluate/inspect a given sequence (host.runner.score(),
+      inspect()); always resolves to ConditionalMode unless straight_through is requested.
+
+  Returns
+  -------
+  ConditionalMode | AutoregressiveMode | STEMode
+
+  """
+  from aminx.inference.decode.mode import AutoregressiveMode, ConditionalMode, STEMode
+
+  if run_spec.sampling.sampling_strategy == "straight_through":
+    return STEMode()
+  if purpose == "sample":
+    return AutoregressiveMode()
+  return ConditionalMode()
+
+
+def make_inference_plan(
+  model: ModelProtocol,
+  spec: Any,
+  packer: Any = None,
+  *,
+  purpose: Literal["sample", "score"] = "score",
+) -> InferencePlan:
   """Factory: resolve and create an InferencePlan from model and spec.
 
   Assembles the inference pipeline by resolving encode_fn (from use_rolling_state),
@@ -741,8 +792,13 @@ def make_inference_plan(model: ModelProtocol, spec: Any, packer: Any = None) -> 
   model : ModelProtocol
       Parameterized model with decoder, encoder, and embeddings.
   spec : Any
-      Specification with attributes: use_rolling_state, multi_state_strategy,
-      multi_state_temperature, state_weights.
+      Specification; decode-relevant fields are read from ``spec.run_spec.sampling``
+      (use_rolling_state, multi_state_strategy, multi_state_temperature, state_weights,
+      sampling_strategy, decoding_order_fn -- see ``run/spec.py::SamplingConfig``).
+  purpose : {"sample", "score"}, keyword-only, default "score"
+      Passed to :func:`resolve_decode_mode` -- disambiguates "produce new sequences"
+      (``host.runner.sample()``) from "evaluate a given sequence" (``score()``/``inspect()``),
+      since ``sampling_strategy`` alone cannot (see ``resolve_decode_mode``'s docstring).
 
   Returns
   -------
@@ -782,17 +838,18 @@ def make_inference_plan(model: ModelProtocol, spec: Any, packer: Any = None) -> 
 
   """
   from aminx.inference.decode.factory import make_decode_fn
-  from aminx.inference.decode.mode import ConditionalMode, STEMode
   from aminx.inference.encode import make_encode_fn
   from aminx.inference.logits import make_stage_set
   from aminx.tiling.strategy import Vmap
 
-  use_rolling_state = getattr(spec, "use_rolling_state", False)
+  sampling_config = spec.run_spec.sampling
+
+  use_rolling_state = sampling_config.use_rolling_state
   encode_fn = make_encode_fn(model, use_rolling_state=use_rolling_state)
 
-  strategy_name = getattr(spec, "multi_state_strategy", None) or "arithmetic_mean"
-  strategy_temp = getattr(spec, "multi_state_temperature", 1.0) or 1.0
-  state_weights = getattr(spec, "state_weights", None)
+  strategy_name = sampling_config.multi_state_strategy or "arithmetic_mean"
+  strategy_temp = sampling_config.multi_state_temperature or 1.0
+  state_weights = sampling_config.state_weights
 
   stage_set = make_stage_set(strategy_name, strategy_temp, state_weights)
 
@@ -822,7 +879,7 @@ def make_inference_plan(model: ModelProtocol, spec: Any, packer: Any = None) -> 
     )
 
   # Wire STE (straight-through estimator) decode topology
-  if getattr(spec, "sampling_strategy", None) == "straight_through":
+  if sampling_config.sampling_strategy == "straight_through":
     import equinox as eqx
 
     from aminx.types.stages import ConditionalDecodeStep
@@ -839,15 +896,18 @@ def make_inference_plan(model: ModelProtocol, spec: Any, packer: Any = None) -> 
     )
     # sample_step stays None (already None from make_stage_set) — teacher-forced path
 
-  # Resolve decode_fn via make_decode_fn. Route mode from spec.sampling_strategy.
-  # - sampling_strategy="straight_through" → STEMode (STE refinement)
-  # - All other strategies (temperature, etc.) → ConditionalMode (default)
-  if getattr(spec, "sampling_strategy", None) == "straight_through":
-    decode_mode = STEMode()
-  else:
-    decode_mode = ConditionalMode()
+  # Resolve decode_fn via the shared resolver (aminx#110: this is the ONE place both this
+  # function and sample_multistate_poe_bead decide which DecodeMode to build -- see
+  # resolve_decode_mode's docstring for why sampling_strategy alone can't disambiguate
+  # "sample" from "score" callers).
+  decode_mode = resolve_decode_mode(spec.run_spec, purpose=purpose)
   decode_strategy = Vmap()
-  decode_fn = make_decode_fn(model, mode=decode_mode, strategy=decode_strategy)
+  decode_fn = make_decode_fn(
+    model,
+    mode=decode_mode,
+    strategy=decode_strategy,
+    decoding_order_fn=sampling_config.decoding_order_fn,
+  )
 
   components = InferenceComponents(
     encode_fn=encode_fn,

--- a/src/aminx/host/plan.py
+++ b/src/aminx/host/plan.py
@@ -819,12 +819,20 @@ def make_inference_plan(
      across tied positions).
   5. ``decode_step`` and ``sample_step`` — for ``sampling_strategy="straight_through"``,
      ``decode_step`` is wired to ``ConditionalDecodeStep`` and ``sample_step`` remains
-     ``None`` (teacher-forced path). All other strategies leave both slots as ``None``;
-     driver selects topology at call time based on stage_set slot occupancy.
+     ``None`` (teacher-forced path). All other strategies leave both slots as ``None``.
+     Note: the pre-260716 note here about "driver selects topology at call time based on
+     stage_set slot occupancy" described the now-deprecated ``inference/driver.py`` dispatch
+     mechanism (``driver.decode()`` raises ``NotImplementedError`` today) -- decode dispatch is
+     resolved once below, at plan-construction time, via ``resolve_decode_mode``, not at call
+     time from stage_set slot occupancy.
   6. ``encoding_fusion`` — wired as ``ArithmeticMeanEncodingFusion`` when
      ``spec.average_node_features=True``; otherwise left ``None``.
-  7. ``decode_fn`` — resolved via make_decode_fn(model, mode, strategy) and wired as
-     a top-level field on the plan.
+  7. ``decode_fn`` — resolved via ``resolve_decode_mode(spec.run_spec, purpose=purpose)`` (see
+     that function's docstring) then ``make_decode_fn(model, mode, strategy, decoding_order_fn)``,
+     and wired as a top-level field on the plan. ``purpose`` is what lets this same factory serve
+     both ``sample()`` (real autoregressive sampling) and ``score()``/``inspect()`` (teacher-forced
+     evaluation) correctly -- see ``resolve_decode_mode`` for why ``sampling_strategy`` alone
+     can't make that distinction (aminx#110).
 
   References
   ----------

--- a/src/aminx/host/prep.py
+++ b/src/aminx/host/prep.py
@@ -129,18 +129,43 @@ def prep_protein_stream_and_model(
   if spec.run_spec.io.cache_path is not None:
     jax.config.update("jax_compilation_cache_dir", str(spec.run_spec.io.cache_path))
 
+  # These three MUST reach load_model, not just the dataset. They change how the model is
+  # BUILT, not merely what it is fed:
+  #   - use_side_chain_context -> weights.py's ligand skeleton (ligand models only; the
+  #     protein branch ignores it, so forwarding is safe for every checkpoint family)
+  #   - use_electrostatics / use_vdw -> physics_feature_dim (weights.py:206-207)
+  # Until now prep.py forwarded electrostatics/vdw to the DATASET (:111, :114) and nothing to
+  # load_model, so a caller asking for sidechain context got a model built with sidechains
+  # off and no error -- occurrences #6 and #11 of the audit's declared-but-never-delivered
+  # class. training/trainer.py:159-164 already forwards these; the inference path did not.
+  #
+  # bool(...) because the spec fields are `bool | None` (specs.py:241,254,255) while
+  # load_model takes plain bools -- None means "not set", i.e. off.
+  #
+  # If a checkpoint has no physics weights and the caller asks for physics, deserialization
+  # now fails loudly. That is the correct outcome: it is what "I asked for electrostatics"
+  # should do when the checkpoint cannot provide them. Silently ignoring the request is the
+  # bug being fixed.
+  model_conditioning = {
+    "use_side_chain_context": bool(spec.ligand_mpnn_use_side_chain_context),
+    "use_electrostatics": bool(spec.use_electrostatics),
+    "use_vdw": bool(spec.use_vdw),
+  }
+
   if spec.checkpoint_id is not None:
     model = load_model(
       checkpoint_id=spec.checkpoint_id,
       model_weights=spec.model_weights,
       model_version=spec.model_version,
       local_path=local_ckpt,
+      **model_conditioning,
     )
   else:
     model = load_model(
       model_version=spec.model_version,
       model_weights=spec.model_weights,
       local_path=local_ckpt,
+      **model_conditioning,
     )
 
   # Set model to inference mode (disables dropout, etc.)

--- a/src/aminx/host/runner.py
+++ b/src/aminx/host/runner.py
@@ -159,8 +159,11 @@ def sample(
 
   protein_iterator, model = prep_protein_stream_and_model(spec)
 
-  # Construct inference plan once before routing to streaming or non-streaming path
-  plan: InferencePlan = make_inference_plan(model, spec)
+  # Construct inference plan once before routing to streaming or non-streaming path.
+  # purpose="sample": this is the one caller that wants new sequences, not a score of a given
+  # one -- aminx#110 was this exact resolution defaulting to ConditionalMode (score-shaped)
+  # here with no way to ask for real autoregressive sampling.
+  plan: InferencePlan = make_inference_plan(model, spec, purpose="sample")
 
   if spec.run_spec.io.output_h5_path:
     return _sample_streaming(spec, protein_iterator, plan, _sample_batch)
@@ -496,7 +499,8 @@ def score(  # noqa: PLR0915
   if spec.average_node_features:
     from aminx.host.plan import make_inference_plan  # noqa: PLC0415
 
-    plan = make_inference_plan(model, spec)
+    # purpose="score" (the default): this call evaluates a given sequence, it never samples one.
+    plan = make_inference_plan(model, spec, purpose="score")
     score_fn = _make_averaged_score_fn(plan, spec)  # type: ignore[arg-type]
   else:
     score_fn = make_score_fn(model)  # type: ignore[arg-type]
@@ -704,7 +708,9 @@ def inspect(  # noqa: PLR0915
 
   # Stage set flows from the inference plan (single construction) rather than a
   # direct make_stage_set import — keeps runner.py free of make_stage_set (COMP-534).
-  unconditional_stage_set = make_inference_plan(model, spec).stage_set
+  # purpose="score": only .stage_set is used below, decode_fn is never invoked from this
+  # plan, but "score" is still the semantically correct purpose for an inspection call.
+  unconditional_stage_set = make_inference_plan(model, spec, purpose="score").stage_set
 
   results_per_feature = {feat: [] for feat in spec.inspection_features}
   distance_matrices: list[jax.Array] = []

--- a/src/aminx/host/runner.py
+++ b/src/aminx/host/runner.py
@@ -769,9 +769,14 @@ def inspect(  # noqa: PLR0915
           results_per_feature[feature_name].append(logits)
 
         elif feature_name == "conditional_logits":
-          # Use native sequence from parsed structure
+          # Use native sequence from parsed structure, converted to the model's alphabet.
+          # aatype is AF; the model's token space is MPNN. Note :802 below already converts
+          # candidate *strings* via string_to_protein_sequence -- the two alphabets were
+          # ~30 lines apart in this same loop, compared against each other.
+          from aminx.utils.aa_convert import af_to_mpnn  # noqa: PLC0415
+
           if hasattr(batched_ensemble, "aatype") and batched_ensemble.aatype is not None:
-            native_seq = batched_ensemble.aatype[struct_idx]
+            native_seq = af_to_mpnn(batched_ensemble.aatype[struct_idx])
           else:
             msg = (
               "Structure does not contain sequence information; cannot compute conditional_logits"
@@ -829,8 +834,10 @@ def inspect(  # noqa: PLR0915
           results_per_feature[feature_name].append(batched_logits)
 
         elif feature_name == "decoded_node_features":
+          from aminx.utils.aa_convert import af_to_mpnn  # noqa: PLC0415
+
           if hasattr(batched_ensemble, "aatype") and batched_ensemble.aatype is not None:
-            native_seq = batched_ensemble.aatype[struct_idx]
+            native_seq = af_to_mpnn(batched_ensemble.aatype[struct_idx])  # AF -> model space
           else:
             msg = "Structure does not contain sequence information; cannot compute decoded_node_features"
             raise ValueError(msg)
@@ -1009,8 +1016,10 @@ def jacobian(
         struct_residue_index = batched_ensemble.residue_index[struct_idx]
         struct_chain_index = batched_ensemble.chain_index[struct_idx]
 
+        from aminx.utils.aa_convert import af_to_mpnn  # noqa: PLC0415
+
         if hasattr(batched_ensemble, "aatype") and batched_ensemble.aatype is not None:
-          native_seq = batched_ensemble.aatype[struct_idx]
+          native_seq = af_to_mpnn(batched_ensemble.aatype[struct_idx])  # AF -> model space
         else:
           msg = "Structure does not contain sequence information; cannot compute Jacobian"
           raise ValueError(msg)

--- a/src/aminx/host/runner.py
+++ b/src/aminx/host/runner.py
@@ -356,7 +356,7 @@ def _make_averaged_score_fn(
     residue_index: jax.Array,
     chain_index: jax.Array,
     backbone_noise: float | None = None,
-    ar_mask: jax.Array | None = None,
+    ar_mask_override: jax.Array | None = None,
     structure_mapping: jax.Array | None = None,
     tie_group_map: jax.Array | None = None,
     multi_state_strategy: str = "arithmetic_mean",
@@ -379,9 +379,12 @@ def _make_averaged_score_fn(
 
     L = int(sequence.shape[0])
 
-    # Build decoding AR mask: use provided ar_mask or default full-context mask
-    if ar_mask is not None:
-      ar_mask_single = ar_mask[0] if ar_mask.ndim == 3 else ar_mask
+    # Build decoding AR mask: use provided override or default full-context mask. This is a
+    # direct caller-supplied override, not sourced from any RunSpecification field -- aminx#113
+    # confirmed the spec-level `ar_mask` field (now deleted) never fed anything; this parameter
+    # is unrelated and always was.
+    if ar_mask_override is not None:
+      ar_mask_single = ar_mask_override[0] if ar_mask_override.ndim == 3 else ar_mask_override
     else:
       ar_mask_single = None  # bundle_builder will create the default
 

--- a/src/aminx/host/spec_partition.py
+++ b/src/aminx/host/spec_partition.py
@@ -58,10 +58,13 @@ CAMPAIGN_OWNED_KEYS: frozenset[str] = frozenset(
 # Fields that genuinely cannot cross the manifest's JSON boundary. Each entry is the REASON,
 # and it must name a mechanism -- "it contains a callable" is a reason; "not applicable" is not.
 #
-# `run_specification_to_json_dict` already refuses these by raising SpecJSONEncodeError, so this
-# set does not suppress anything; it documents *why* the raise is correct and gives the
-# completeness check something to check against. Setting one of these on a campaign base_spec is
-# an error, not a silent no-op -- that change (silent-drop -> loud error) is the entire point.
+# CORRECTED. An earlier version of this comment claimed `run_specification_to_json_dict` "already
+# refuses these by raising", so setting one was "an error, not a silent no-op". **That was false
+# for the three callable fields**: spec_json does `if callable(val): continue`
+# (spec_json.py:141), so a real `decoding_order_fn` -- a supported knob -- was still SILENTLY
+# DROPPED by the campaign. I asserted the impossibility of the exact bug this module exists to
+# end, in this module, and shipped it. `_CALLABLE_FIELDS` + `_assert_no_callable_knobs` below
+# make the claim true instead of deleting it.
 EXCLUDED_WITH_REASON: Mapping[str, str] = {
   "run_spec": "init=False; rebuilt by __post_init__ from the other fields",
   "_run_spec_synced": "init=False; an internal guard flag",
@@ -154,6 +157,42 @@ def assert_partition_is_exhaustive() -> None:
     raise SpecPartitionError(msg)
 
 
+# Callable-valued knobs. spec_json DROPS these silently (`if callable(val): continue`,
+# spec_json.py:141) rather than raising, because `aminx spec emit-*` may legitimately want a
+# best-effort export. A campaign row may not: a manifest that omits a caller's decoding_order_fn
+# produces designs from a DIFFERENT decoding order than requested, silently -- the audit's exact
+# failure mode. Refuse in the campaign path only; do not change spec_json's behavior for its
+# other callers.
+_CALLABLE_FIELDS: Mapping[str, str] = {
+  "decoding_order_fn": "pass a decode strategy the manifest can name, or run outside a campaign",
+  "encoding_fusion": "encoding fusion is a composable Python-API step; it cannot be named in JSON",
+  "decoding_fusion": "decoding fusion is a composable Python-API step; it cannot be named in JSON",
+}
+
+
+def _assert_no_callable_knobs(spec: SamplingSpecification) -> None:
+  """Refuse a callable knob rather than dropping it silently.
+
+  Raises:
+    SpecPartitionError: a callable-valued field is set on a campaign spec.
+
+  """
+  offenders = [
+    f"{name} ({hint})"
+    for name, hint in _CALLABLE_FIELDS.items()
+    if callable(getattr(spec, name, None))
+  ]
+  if offenders:
+    msg = (
+      "Callable knob(s) set on a campaign spec, which the manifest cannot carry: "
+      + "; ".join(offenders)
+      + ". spec_json drops callables silently, so this would run with the DEFAULT and produce "
+      "designs that differ from what you asked for, with no error -- the failure this audit "
+      "exists to end. Refusing instead."
+    )
+    raise SpecPartitionError(msg)
+
+
 def campaign_sampling_spec_payload(
   spec_variant: SamplingSpecification,
   *,
@@ -177,6 +216,8 @@ def campaign_sampling_spec_payload(
       loud by design; these were previously dropped in silence.
 
   """
+  _assert_no_callable_knobs(spec_variant)
+
   supplied = set(campaign_owned)
   if supplied != CAMPAIGN_OWNED_KEYS:
     missing, extra = CAMPAIGN_OWNED_KEYS - supplied, supplied - CAMPAIGN_OWNED_KEYS

--- a/src/aminx/host/spec_partition.py
+++ b/src/aminx/host/spec_partition.py
@@ -1,0 +1,195 @@
+"""Serialize a SamplingSpecification exhaustively, or fail loudly.
+
+Twelve control knobs were declared on aminx's config surface, appeared to work, and silently
+never reached the model. All twelve had one root cause: ``plan_campaign_manifest`` serialized
+the spec through a **hand-written dict literal of 23 keys**, with no coupling to
+``dataclasses.fields(SamplingSpecification)`` (88 fields). Nothing enforced the sync, so a
+field's absence was indistinguishable from a caller wanting the default. Over ~5 weeks, eleven
+separate bugs; every one found incidentally, none by a sweep. The worst -- ``fixed_mask`` --
+meant no residue was ever held fixed in any produced design, silently violating a locked
+preregistration.
+
+The fix is not a better literal. It is **removing the opportunity to write one**: build the
+payload from the dataclass itself, and require every field to be classified. A field nobody
+classified fails the build instead of vanishing.
+
+Three classifications, and the distinction is load-bearing:
+
+- **serialized** -- dumped from the spec; the caller's value reaches the worker.
+- **campaign-owned** -- the planner owns this per row, so the caller's value is *replaced*, not
+  dropped (``job_id``, ``grid_mode``, ...). A naive differential reports these as "not wired";
+  they are not bugs.
+- **excluded** -- genuinely cannot cross the JSON boundary, *with a cited reason*. Today only
+  callables and nested dataclasses.
+
+task_id: 260715_aminx-campaign-control-knob-audit
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import TYPE_CHECKING, Any
+
+from aminx.run.spec_json import run_specification_to_json_dict
+from aminx.run.specs import SamplingSpecification
+
+if TYPE_CHECKING:
+  from collections.abc import Mapping
+
+# Keys the PLANNER owns per row. The caller's value is deliberately replaced, not dropped --
+# these describe the row's place in the campaign, not the caller's intent.
+#
+# Only 7. `campaign_mode`/`return_logits`/`ligand_conditioning`/`sidechain_conditioning` are NOT
+# here: `plan_campaign_manifest` already sets them on `spec_variant` via `replace()`, so the
+# field-driven dump reproduces them. Of the hardcoded trio only `grid_mode` needs an override,
+# because `specs.py`'s default is False and `replace()` never touches it.
+CAMPAIGN_OWNED_KEYS: frozenset[str] = frozenset(
+  {
+    "grid_mode",
+    "samples_chunk_size",
+    "job_id",
+    "chunk_id",
+    "sample_start",
+    "sample_count",
+    "output_h5_path",
+  },
+)
+
+# Fields that genuinely cannot cross the manifest's JSON boundary. Each entry is the REASON,
+# and it must name a mechanism -- "it contains a callable" is a reason; "not applicable" is not.
+#
+# `run_specification_to_json_dict` already refuses these by raising SpecJSONEncodeError, so this
+# set does not suppress anything; it documents *why* the raise is correct and gives the
+# completeness check something to check against. Setting one of these on a campaign base_spec is
+# an error, not a silent no-op -- that change (silent-drop -> loud error) is the entire point.
+EXCLUDED_WITH_REASON: Mapping[str, str] = {
+  "run_spec": "init=False; rebuilt by __post_init__ from the other fields",
+  "_run_spec_synced": "init=False; an internal guard flag",
+  "decoding_order_fn": "a callable; cannot cross a JSON boundary",
+  "encoding_fusion": "a callable; cannot cross a JSON boundary",
+  "decoding_fusion": "a callable; cannot cross a JSON boundary",
+  "foldcomp_database": "a live database handle; cannot cross a JSON boundary",
+  "conformational_states": (
+    "an arbitrary object satisfying the ConformationalStates protocol; _to_json_value has no "
+    "branch for it and raises"
+  ),
+  "carry_specs": (
+    "list[CarrySpec]; CarrySpec.transition is a callable and .init holds JAX arrays. A campaign "
+    "row genuinely cannot carry a Scan axis -- setting this is an error, not a dropped knob"
+  ),
+  "dedup_specs": (
+    "list[DedupSpec]; dedup_fn/gather_fn are callables. A campaign row genuinely cannot carry a "
+    "dedup axis -- setting this is an error, not a dropped knob"
+  ),
+}
+
+
+# Fields __post_init__ DERIVES from other, serialized fields. Not carried, and losslessly so --
+# verified in BOTH directions, because "derived" is only safe if the derivation is invertible:
+#   backbone_noise=0.25             -> noise == [FeatureNoiseBundle(feature_type='backbone', ...)]
+#   noise=[FeatureNoiseBundle(...)] -> backbone_noise == (0.3,)   (back-populated)
+# The second direction is the load-bearing one: without it, a caller using the unified `noise`
+# API and never touching `backbone_noise` would silently lose their setting.
+DERIVED_FIELDS: frozenset[str] = frozenset({"noise"})
+
+
+class SpecPartitionError(RuntimeError):
+  """A spec field is classified nowhere, so its fate would be silent.
+
+  This is the guard the manifest literal never had. It fires at import, not at sampling time --
+  a knob that silently fails to reach the model is only discoverable weeks later, in results.
+  """
+
+
+def _spec_field_names() -> set[str]:
+  return {f.name for f in fields(SamplingSpecification)}
+
+
+def assert_partition_is_exhaustive() -> None:
+  """Every SamplingSpecification field must be classified. Raise if any is not.
+
+  Runs at import so a newly-added spec field breaks the build immediately, rather than being
+  silently omitted from every manifest until someone notices the science is wrong.
+  """
+  actual = _spec_field_names()
+
+  # A field is classified if it is excluded, planner-owned, or dumped by spec_json. The dump is
+  # the source of truth for "serialized" -- asking it is what keeps this honest, versus keeping
+  # a third hand-written list that could drift exactly like the literal did.
+  #
+  # The probe must RESEMBLE A REAL CAMPAIGN SPEC, not take defaults. An earlier version used
+  # bare defaults and passed -- but `noise` is empty at defaults and only populates once
+  # `backbone_noise` is set (which every campaign does), at which point the dump raises on a
+  # nested dataclass. A probe that cannot reach the failing path is a false green, which is the
+  # exact bug class this module exists to prevent.
+  probe = SamplingSpecification(
+    inputs=["_partition_probe.pdb"],
+    checkpoint_id="ligandmpnn_v_32_020_25",
+    backbone_noise=0.25,
+    temperature=0.1,
+    campaign_mode=True,
+    return_logits=False,
+  )
+  dumped = set(run_specification_to_json_dict(probe)) - {"_spec_class"}
+
+  classified = dumped | set(EXCLUDED_WITH_REASON) | CAMPAIGN_OWNED_KEYS | DERIVED_FIELDS
+  unclassified = actual - classified
+  if unclassified:
+    msg = (
+      f"SamplingSpecification field(s) classified nowhere: {sorted(unclassified)}. Every field "
+      f"must be serialized by spec_json, listed in CAMPAIGN_OWNED_KEYS, or in "
+      f"EXCLUDED_WITH_REASON with a reason naming a mechanism. An unclassified field is exactly "
+      f"how twelve knobs silently never reached the model."
+    )
+    raise SpecPartitionError(msg)
+
+  stale = (set(EXCLUDED_WITH_REASON) | CAMPAIGN_OWNED_KEYS) - actual
+  if stale:
+    msg = f"Classified name(s) that are no longer SamplingSpecification fields: {sorted(stale)}"
+    raise SpecPartitionError(msg)
+
+  vague = [name for name, reason in EXCLUDED_WITH_REASON.items() if len(reason.split()) < 4]
+  if vague:
+    msg = f"EXCLUDED_WITH_REASON entries needing a real reason: {vague}"
+    raise SpecPartitionError(msg)
+
+
+def campaign_sampling_spec_payload(
+  spec_variant: SamplingSpecification,
+  *,
+  campaign_owned: Mapping[str, Any],
+) -> dict[str, Any]:
+  """Build a manifest row's ``sampling_spec`` from the dataclass, not by hand.
+
+  Args:
+    spec_variant: The per-variant spec the planner built via ``replace()``.
+    campaign_owned: Per-row values the planner owns; keys must be ``CAMPAIGN_OWNED_KEYS``.
+
+  Returns:
+    A JSON-safe payload that reconstructs via ``SamplingSpecification(**payload)`` -- the
+    worker's real path. ``_spec_class`` is removed deliberately: the worker uses the plain
+    constructor, which rejects unknown keys with a TypeError. ``run_specification_from_json_dict``
+    would instead *silently ignore* them, which would trade one silent-failure class for another.
+
+  Raises:
+    SpecPartitionError: ``campaign_owned`` does not match ``CAMPAIGN_OWNED_KEYS`` exactly.
+    SpecJSONEncodeError: a field cannot cross the JSON boundary (see EXCLUDED_WITH_REASON) --
+      loud by design; these were previously dropped in silence.
+
+  """
+  supplied = set(campaign_owned)
+  if supplied != CAMPAIGN_OWNED_KEYS:
+    missing, extra = CAMPAIGN_OWNED_KEYS - supplied, supplied - CAMPAIGN_OWNED_KEYS
+    msg = (
+      f"campaign_owned must supply exactly CAMPAIGN_OWNED_KEYS; missing={sorted(missing)}, "
+      f"unexpected={sorted(extra)}"
+    )
+    raise SpecPartitionError(msg)
+
+  payload = run_specification_to_json_dict(spec_variant)
+  payload.pop("_spec_class", None)
+  payload.update(campaign_owned)
+  return payload
+
+
+assert_partition_is_exhaustive()

--- a/src/aminx/host/streaming.py
+++ b/src/aminx/host/streaming.py
@@ -18,6 +18,7 @@ from aminx.host._sampling_grid_lineage import (
 from aminx.host._sampling_helper import (
   _canonical_structure_ids_for_spec,
   _structure_ids_for_batch,
+  fixed_provenance_outputs,
 )
 from aminx.host.output_sinks import (
   streaming_tensor_sink_session,
@@ -206,11 +207,18 @@ def _sample_streaming(
 
         for key in structure_keys:
           concat_arrays: dict[str, np.ndarray] = {"sequences": np.concatenate(seq_parts[key], axis=0)}
+          # The evidence that anything was actually held fixed. Emitted beside the sequences
+          # so a reader can CHECK them against it; without this the mask reached the model
+          # and vanished, and 882/882 rows completed with valid digests and void science.
+          fixed_arrays, fixed_attrs = fixed_provenance_outputs(
+            spec, seq_len=int(batched_ensemble.coordinates.shape[1]),
+          )
+          concat_arrays.update(fixed_arrays)
           if logits_parts[key]:
             concat_arrays["logits"] = np.concatenate(logits_parts[key], axis=0)
           if perplexity_parts[key]:
             concat_arrays["pseudo_perplexity"] = np.concatenate(perplexity_parts[key], axis=0)
-          sink.stage(key, **concat_arrays)
+          sink.stage(key, attrs=fixed_attrs, **concat_arrays)
 
   sink.drain()
 

--- a/src/aminx/run/spec.py
+++ b/src/aminx/run/spec.py
@@ -95,7 +95,18 @@ class PlannerTopology(eqx.Module):
 
 
 class SamplingConfig(eqx.Module):
-  """Generic sampling knobs (RS-1 migration map section 4)."""
+  """Generic sampling knobs (RS-1 migration map section 4).
+
+  ``sampling_strategy`` through ``structure_mapping`` below were added 260716 (EPIC #1541 P4,
+  the decode-plan-unification pass) so that decode-class resolution (``ConditionalMode`` vs
+  ``AutoregressiveMode`` vs ``STEMode``) and multistate/tie fusion can be driven from ONE place
+  (``spec.run_spec.sampling``) instead of scattered flat-spec reads across ``host/plan.py`` and
+  ``sampling/multistate_poe.py`` independently. See aminx#110/#113 and
+  ``.praxia/docs/specs/260707_xtrax-migration-gap-audit-runspec-scaffolding.md`` for why the
+  prior attempt at this (``TiedPositionsConfig``/``AveragingConfig``/``BatchingConfig``) went
+  100% dead and was deleted (`dd0e952`) rather than fixed -- fields live directly on
+  ``SamplingConfig`` this time, not a separate sub-config, since that's the one that stuck.
+  """
 
   num_samples: int = eqx.field(static=True)
   random_seed: int = eqx.field(static=True)
@@ -109,6 +120,15 @@ class SamplingConfig(eqx.Module):
   fixed_mask: Any = None
   fixed_positions: Any = None
   fixed_tokens: Any = None
+  sampling_strategy: str = eqx.field(static=True, default="temperature")
+  multi_state_strategy: str = eqx.field(static=True, default="arithmetic_mean")
+  multi_state_temperature: float = eqx.field(static=True, default=1.0)
+  use_rolling_state: bool = eqx.field(static=True, default=False)
+  decoding_order_fn: Any = eqx.field(static=True, default=None)
+  tie_group_map: Any = None
+  state_position_map: Any = None
+  state_weights: Any = None
+  structure_mapping: Any = None
 
 
 class RunSpec(_XtraxRunSpec):
@@ -315,6 +335,17 @@ def build_run_spec(spec: object) -> RunSpec:
     fixed_mask=getattr(spec, "fixed_mask", None),
     fixed_positions=getattr(spec, "fixed_positions", None),
     fixed_tokens=getattr(spec, "fixed_tokens", None),
+    sampling_strategy=str(getattr(spec, "sampling_strategy", "temperature") or "temperature"),
+    multi_state_strategy=str(
+      getattr(spec, "multi_state_strategy", "arithmetic_mean") or "arithmetic_mean",
+    ),
+    multi_state_temperature=float(getattr(spec, "multi_state_temperature", 1.0) or 1.0),
+    use_rolling_state=bool(getattr(spec, "use_rolling_state", False)),
+    decoding_order_fn=getattr(spec, "decoding_order_fn", None),
+    tie_group_map=getattr(spec, "tie_group_map", None),
+    state_position_map=getattr(spec, "state_position_map", None),
+    state_weights=getattr(spec, "state_weights", None),
+    structure_mapping=getattr(spec, "structure_mapping", None),
   )
 
   return RunSpec(

--- a/src/aminx/run/spec_json.py
+++ b/src/aminx/run/spec_json.py
@@ -203,7 +203,6 @@ def _coerce_field_value(_cls: type[Any], field_name: str, value: Any) -> Any:
     "tie_group_map",
     "state_position_map",
     "structure_mapping",
-    "ar_mask",
     "bias",
     "fixed_positions",
     "fixed_mask",

--- a/src/aminx/run/spec_json.py
+++ b/src/aminx/run/spec_json.py
@@ -107,6 +107,19 @@ _NON_JSON_ROOT_FIELDS = frozenset(
   },
 )
 
+# Fields __post_init__ DERIVES from other, serialized fields. Skipped on encode and rebuilt on
+# decode, so omitting them is lossless -- verified both directions:
+#   - set backbone_noise=0.25            -> noise == [FeatureNoiseBundle(feature_type='backbone', ...)]
+#   - set noise=[FeatureNoiseBundle(...)] -> backbone_noise == (0.3,)   (back-populated)
+# `noise` is `list[FeatureNoiseBundle]`, a nested dataclass `_to_json_value` has no branch for,
+# so without this every real spec would fail to encode: __post_init__ populates `noise` from
+# `backbone_noise`, and every campaign sets `backbone_noise`.
+#
+# Distinct from _NON_JSON_ROOT_FIELDS, which must be None and raises otherwise. These are
+# expected to be non-None and are dropped precisely because they carry no information the
+# serialized fields do not already carry.
+_DERIVED_FIELDS = frozenset({"noise"})
+
 
 def run_specification_to_json_dict(spec: RunSpecification) -> dict[str, Any]:
   """Return a JSON-serializable dict for ``spec`` (includes ``_spec_class``)."""
@@ -130,6 +143,10 @@ def run_specification_to_json_dict(spec: RunSpecification) -> dict[str, Any]:
       if val is not None:
         msg = f"Field {f.name!r} must be None for JSON encoding (got {type(val).__name__})"
         raise SpecJSONEncodeError(msg)
+      continue
+    if f.name in _DERIVED_FIELDS:
+      # __post_init__ rebuilds it from serialized fields; carrying it would be redundant, and
+      # it is a nested dataclass _to_json_value cannot encode anyway.
       continue
     raw = getattr(spec, f.name)
     if f.name == "inputs":

--- a/src/aminx/run/specs.py
+++ b/src/aminx/run/specs.py
@@ -196,7 +196,6 @@ class RunSpecification:
       backbone_noise: The backbone noise levels to use (default is (0.0,)).
                       Can be a single float or a sequence of floats.
       foldcomp_database: An optional path to a FoldComp database (default is None).
-      ar_mask: An optional array-like mask for autoregressive positions (default is None).
       random_seed: The random seed to use (default is 42).
       chain_id: An optional chain ID to use (default is None).
       model: An optional model ID to use (default is None).
@@ -254,7 +253,6 @@ class RunSpecification:
   use_electrostatics: bool | None = None
   use_vdw: bool | None = None
   foldcomp_database: FoldCompDatabase | None = None
-  ar_mask: None | ArrayLike = None
   random_seed: int = 42
   chain_id: Sequence[str] | str | None = None
   model: int | None = None

--- a/src/aminx/sampling/multistate_poe.py
+++ b/src/aminx/sampling/multistate_poe.py
@@ -60,7 +60,12 @@ from aminx.host._sampling_helper import (
   _prepare_ligand_context,
   fixed_provenance_outputs,
 )
-from aminx.host.plan import resolve_chunk_size, resolve_sample_start, resolve_target_samples
+from aminx.host.plan import (
+  resolve_chunk_size,
+  resolve_decode_mode,
+  resolve_sample_start,
+  resolve_target_samples,
+)
 from aminx.host.prep import prep_protein_stream_and_model
 from aminx.host.streaming import GRID_SCHEMA_VERSION, SAMPLING_SCHEMA_VERSION, _grid_lineage_attrs
 from aminx.inference.bundle_builder import build_inference_bundle
@@ -351,6 +356,24 @@ def sample_multistate_poe_bead(
     strategy_temperature=getattr(spec, "multi_state_temperature", 1.0) or 1.0,
     state_weights=state_weights,
   )
+
+  # Consult the SAME decode-mode resolver host/plan.py::make_inference_plan uses (aminx#110):
+  # this function is hardwired to sample_states_fused's AutoregressiveMode-only kernel, so a
+  # caller asking for anything else (today, only sampling_strategy="straight_through") must be
+  # told loudly that this path can't honor it, rather than have the request silently ignored --
+  # which is exactly how #110 went unnoticed for as long as it did.
+  from aminx.inference.decode.mode import AutoregressiveMode  # noqa: PLC0415
+
+  decode_mode = resolve_decode_mode(spec.run_spec, purpose="sample")
+  if not isinstance(decode_mode, AutoregressiveMode):
+    msg = (
+      f"sample_multistate_poe_bead only implements AutoregressiveMode sampling, but "
+      f"spec.sampling_strategy={spec.sampling_strategy!r} resolves to "
+      f"{type(decode_mode).__name__} via the shared resolver. straight_through (STE) "
+      f"sampling is not wired for genuine multi-state PoE beads -- only the default "
+      f"autoregressive path is supported here."
+    )
+    raise NotImplementedError(msg)
 
   return sample_states_fused(model, bundle, config, stage_set, prng_key, n_samples)
 

--- a/src/aminx/sampling/multistate_poe.py
+++ b/src/aminx/sampling/multistate_poe.py
@@ -58,6 +58,7 @@ from aminx.host._sampling_helper import (
   _canonical_structure_ids_for_spec,
   _prepare_fixed_controls,
   _prepare_ligand_context,
+  fixed_provenance_outputs,
 )
 from aminx.host.plan import resolve_chunk_size, resolve_sample_start, resolve_target_samples
 from aminx.host.prep import prep_protein_stream_and_model
@@ -559,6 +560,12 @@ def sample_multistate_poe_campaign_row(spec: SamplingSpecification) -> dict[str,
   }
   if grid_lineage is not None:
     attrs.update(_grid_lineage_attrs(grid_lineage))
+  # Same provenance as the single-structure branch. These two writers share no write function
+  # -- they only share the sink primitive -- so anything added to one and not the other leaves
+  # exactly the arm that matters here (the necklace's PoE beads) with no evidence at all.
+  fixed_arrays, fixed_attrs = fixed_provenance_outputs(spec, seq_len=int(seq_len))
+  arrays.update(fixed_arrays)
+  attrs.update(fixed_attrs)
   sink.stage(key, attrs=attrs, **arrays)
   sink.drain()
 

--- a/tests/host/knob_observations.py
+++ b/tests/host/knob_observations.py
@@ -219,7 +219,6 @@ OBSERVATIONS: dict[str, Verdict] = {
   "use_concrete": NotApplicable(reason="STE-loop knob (optimize_ste.py); unreachable under grid_mode's temperature strategy"),
   "concrete_tau_start": NotApplicable(reason="STE-loop knob; see use_concrete"),
   "concrete_tau_end": NotApplicable(reason="STE-loop knob; see use_concrete"),
-  "ar_mask": NotApplicable(reason="never forwarded to _sample_batch by ANY caller; build_inference_bundle self-derives it from mode/schedule (bundle_builder.py:199-219). Dead spec field."),
   "allow_logits_in_campaign": NotApplicable(reason="return_logits is hardcoded False, so this never fires in a planned row"),
   "logits_memory_budget_mb": NotApplicable(reason="only meaningful with return_logits=True, which campaign hardcodes off"),
   "average_node_features": NotApplicable(reason="validated incompatible with grid_mode, specs.py:549-551"),

--- a/tests/host/knob_observations.py
+++ b/tests/host/knob_observations.py
@@ -1,0 +1,249 @@
+"""Declared expected behavior for every SamplingSpecification field in campaign mode.
+
+This table is the audit's core artifact. It is three things at once:
+
+1. **The harness spec** -- what `test_knob_differential.py` asserts per field.
+2. **The triage record** -- the verdict for each field, with its evidence.
+3. **The drift guard** -- a new spec field with no entry here fails CI.
+
+Why declarations at all, rather than just diffing values through the pipeline: a raw
+differential reports "value did not survive" for `multi_state_strategy` (a real bug) AND for
+`random_seed` (not a bug -- rows are differentiated by a grid-lineage hash instead). The
+mechanical pass produces *questions*; only declared intent turns them into verdicts. A harness
+without this table cries wolf on day one, and a harness that cries wolf gets muted.
+
+Every NOT_APPLICABLE/OVERRIDDEN reason must cite a mechanism or a line, never an assertion.
+Judgment is precisely what failed the ten times this audit exists to answer for.
+
+task_id: 260715_aminx-campaign-control-knob-audit
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Verdict:
+  """Base verdict. `reason` must cite evidence, not assert a conclusion."""
+
+  reason: str
+
+
+@dataclass(frozen=True)
+class Bundle(Verdict):
+  """Reaches the model as a `build_inference_bundle` argument. Tier B observable."""
+
+  param: str
+
+
+@dataclass(frozen=True)
+class LoadModel(Verdict):
+  """Reaches the model skeleton as a `load_model` kwarg. Tier B observable."""
+
+  param: str
+
+
+@dataclass(frozen=True)
+class SpecOnly(Verdict):
+  """Must survive the manifest round trip; affects the loop/plan, not a boundary arg.
+
+  Tier A observable: the reconstructed spec's value must differ when the caller's does.
+  """
+
+
+@dataclass(frozen=True)
+class Overridden(Verdict):
+  """Campaign deliberately overrides the caller. Tier A asserts the override, not the input.
+
+  Without this verdict a naive differential flags these as "not wired" -- false alarms.
+  """
+
+  value: object
+
+
+@dataclass(frozen=True)
+class NotApplicable(Verdict):
+  """Genuinely inert in campaign mode. Asserted inert, so a future wiring change trips it."""
+
+
+@dataclass(frozen=True)
+class NonSerializable(Verdict):
+  """Cannot cross the manifest JSON boundary (callables, live objects)."""
+
+
+@dataclass(frozen=True)
+class Internal(Verdict):
+  """`init=False` plumbing, not a caller-facing knob."""
+
+
+# ---------------------------------------------------------------------------
+# Known-broken at a17. Each entry is xfail(strict=True) in the harness: it must FAIL
+# today (proving the harness detects real bugs) and, once fixed, XPASS -> red build,
+# forcing the marker's removal. Both directions guarded, permanently.
+# ---------------------------------------------------------------------------
+KNOWN_BROKEN_AT_A17: dict[str, str] = {
+  "fixed_mask": "occurrence #7 -- not in the manifest literal; --fixed-policies never resolves to positions",
+  "fixed_positions": "occurrence #7 -- same; also a mask alias, not indices (runner.py:103 misdocuments it)",
+  "fixed_tokens": "occurrence #7 -- same",
+  "state_position_map": "occurrence #8 -- on the spec + spec_json whitelist, absent from campaign.py entirely",
+  "multi_state_strategy": "silently reverts to arithmetic_mean; row hash records the request, falsely implying it was honored",
+  "state_weights": "not in the manifest literal; --state-weight-profiles never resolves a name to weights (occurrence #10)",
+  "bias": "not in the manifest literal",
+  "tie_group_map": "not in the manifest literal",
+  "structure_mapping": "not in the manifest literal",
+  "ligand_mpnn_use_side_chain_context": (
+    "occurrence #6 -- absent from the manifest AND not forwarded prep.py:133,140 -> load_model"
+  ),
+  "use_electrostatics": "not forwarded to load_model at prep.py:133,140 (contrast trainer.py:159-164 which does)",
+  "use_vdw": "same as use_electrostatics",
+}
+
+
+# ---------------------------------------------------------------------------
+# The table. One entry per SamplingSpecification field (88 at a17).
+# ---------------------------------------------------------------------------
+OBSERVATIONS: dict[str, Verdict] = {
+  # --- reaches build_inference_bundle -------------------------------------------------
+  "fixed_mask": Bundle(param="fixed_mask", reason="unioned with fixed_positions in _prepare_fixed_controls, _sampling_helper.py:482"),
+  "fixed_positions": Bundle(param="fixed_mask", reason="unioned into fixed_mask, _sampling_helper.py:482 -- a full-length mask despite the name"),
+  "fixed_tokens": Bundle(param="fixed_tokens", reason="_prepare_fixed_controls, _sampling_helper.py:484-497"),
+  "bias": Bundle(param="bias", reason="threaded to the bundle at kernel_dispatch.py:227 and multistate_poe.py:332"),
+  "tie_group_map": Bundle(param="tie_group_map", reason="threaded to the bundle at kernel_dispatch.py:228"),
+  "state_weights": Bundle(param="state_weights", reason="threaded to the bundle at kernel_dispatch.py:229"),
+  "state_position_map": Bundle(param="state_position_map", reason="broadcast + threaded at kernel_dispatch.py:230-232"),
+  "structure_mapping": Bundle(param="structure_mapping", reason="threaded to the bundle at kernel_dispatch.py:251"),
+  "ligand_context_path": Bundle(param="ligand_coords", reason="_prepare_ligand_context loads the npz, _sampling_helper.py:269-277"),
+  # --- enumerated by the planner, NOT taken from base_spec ------------------------------
+  # Verified: plan_campaign_manifest ignores base_spec's values and emits all 4 combinations
+  # (campaign.py:612-613). A caller asking for ligand=True/sidechain=True gets 4 rows, one of
+  # which is (False, False). This is why tev_design's _patch_row must overwrite both per arm.
+  "ligand_conditioning": Overridden(
+    value=None,
+    reason=(
+      "planner enumerates the 2x2 cross product (campaign.py:612-613); base_spec's value is "
+      "ignored and each combo gets its own row. Separately, at the model boundary this flag does "
+      "NOT gate injection -- model_family does (_sampling_helper.py:255); it only chooses "
+      "raise-vs-zeros when Y is absent (279-285). Unreachable in necklace: proxide's Protein has "
+      "no Y field, and the builder passes the npz iff has_ligand, from the same bool as the flag."
+    ),
+  ),
+  "sidechain_conditioning": Overridden(
+    value=None,
+    reason=(
+      "planner enumerates the 2x2 cross product (campaign.py:612-613); base_spec's value is "
+      "ignored. Gates atom_37/atom_37_mask at the bundle (_sampling_helper.py:315-366), but the "
+      "model is still built with sidechains off because prep.py:133,140 never forward "
+      "use_side_chain_context -- see ligand_mpnn_use_side_chain_context."
+    ),
+  ),
+  "backbone_noise": Bundle(param="backbone_noise", reason="per-cell value from the noise axis loop, kernel_dispatch.py:224"),
+  "temperature": Bundle(param="temperature", reason="per-cell value from the temperature axis loop, kernel_dispatch.py:252"),
+
+  # --- reaches load_model ---------------------------------------------------------------
+  "checkpoint_id": LoadModel(param="checkpoint_id", reason="forwarded at prep.py:133; also drives model_family auto-derivation, specs.py:485"),
+  "model_weights": LoadModel(param="model_weights", reason="forwarded at both load_model call sites, prep.py:133,140"),
+  "model_version": LoadModel(param="model_version", reason="forwarded at both load_model call sites, prep.py:133,140 (legacy alias)"),
+  "model_local_path": LoadModel(param="local_path", reason="resolved at prep.py:129-132"),
+  "checkpoint_registry_path": LoadModel(param="local_path", reason="resolved at prep.py:129-132"),
+  "ligand_mpnn_use_side_chain_context": LoadModel(
+    param="use_side_chain_context",
+    reason="SHOULD reach load_model (io/weights.py:160) but prep.py:133,140 never forward it",
+  ),
+  "use_electrostatics": LoadModel(
+    param="use_electrostatics",
+    reason="SHOULD reach load_model (io/weights.py) -- forwarded to the dataset at prep.py:111 but not the model",
+  ),
+  "use_vdw": LoadModel(param="use_vdw", reason="same as use_electrostatics; prep.py:114 dataset only"),
+
+  # --- must survive the manifest; affects plan/loop, not a boundary arg -----------------
+  "inputs": SpecOnly(reason="drives structure parsing; also selects PoE vs single-input at campaign.py:865"),
+  "model_family": SpecOnly(reason="THE ligand/sidechain gate (_sampling_helper.py:255); auto-derives from checkpoint_id, specs.py:485"),
+  "chain_id": SpecOnly(reason="selects which chains are parsed; JSON-decoded at cli.py:1701"),
+  "multi_state_strategy": SpecOnly(reason="selects stage_set.logit_transform via make_stage_set, plan.py:797"),
+  "batch_size": SpecOnly(reason="dataset batching, prep.py:107; for PoE it becomes bundle.geometry.n_states"),
+
+  # --- campaign deliberately overrides the caller ---------------------------------------
+  "campaign_mode": Overridden(value=True, reason="hardcoded True, campaign.py:673 -- a campaign row is by definition campaign mode"),
+  "return_logits": Overridden(value=False, reason="hardcoded False, campaign.py:674 -- logits are refused in campaign mode unless allow_logits_in_campaign"),
+  "grid_mode": Overridden(value=True, reason="hardcoded True, campaign.py:675"),
+  "samples_chunk_size": Overridden(value=None, reason="overwritten with the row's sample_count, campaign.py:672 -- chunking is the planner's job, not the caller's"),
+
+  # --- genuinely inert in campaign mode --------------------------------------------------
+  "random_seed": NotApplicable(
+    reason=(
+      "RETRACTED as a bug after tracing: _base_sampling_key folds a grid-lineage hash (job_id + "
+      "strategy/conditioning) into the seed so rows differ despite the shared default 42 "
+      "(_sampling_grid_lineage.py); PoE additionally folds sample_start (multistate_poe.py:474, a "
+      "risk an independent PR audit found and closed 260714); the non-PoE path slices a "
+      "deterministic stream. The raw seed not surviving is benign."
+    ),
+  ),
+  "num_samples": NotApplicable(reason="campaign uses the row's sample_count/samples_chunk_size instead; resolve_target_samples, plan.py:323"),
+  "sampling_strategy": NotApplicable(reason="grid_mode requires 'temperature' (validated specs.py:546-551), so a campaign row cannot vary it"),
+  "job_id": NotApplicable(reason="set per-row by the planner, campaign.py:676"),
+  "chunk_id": NotApplicable(reason="set per-row by the planner, campaign.py:677"),
+  "sample_start": NotApplicable(reason="set per-row by the planner, campaign.py:678"),
+  "sample_count": NotApplicable(reason="set per-row by the planner, campaign.py:679"),
+  "output_h5_path": NotApplicable(reason="set per-row by the planner, campaign.py:680; the worker rewrites it to a partial path, campaign.py:854"),
+  "iterations": NotApplicable(reason="straight_through only; grid_mode forbids that strategy"),
+  "learning_rate": NotApplicable(reason="straight_through only; grid_mode forbids that strategy"),
+  "use_concrete": NotApplicable(reason="STE-loop knob (optimize_ste.py); unreachable under grid_mode's temperature strategy"),
+  "concrete_tau_start": NotApplicable(reason="STE-loop knob; see use_concrete"),
+  "concrete_tau_end": NotApplicable(reason="STE-loop knob; see use_concrete"),
+  "ar_mask": NotApplicable(reason="never forwarded to _sample_batch by ANY caller; build_inference_bundle self-derives it from mode/schedule (bundle_builder.py:199-219). Dead spec field."),
+  "allow_logits_in_campaign": NotApplicable(reason="return_logits is hardcoded False, so this never fires in a planned row"),
+  "logits_memory_budget_mb": NotApplicable(reason="only meaningful with return_logits=True, which campaign hardcodes off"),
+  "average_node_features": NotApplicable(reason="validated incompatible with grid_mode, specs.py:549-551"),
+  "compute_pseudo_perplexity": NotApplicable(reason="requires return_logits=True, which campaign hardcodes off"),
+  "return_decoding_orders": NotApplicable(reason="output-shape knob; not carried by the manifest and not a boundary arg"),
+  "return_logit_fingerprint": NotApplicable(reason="output-shape knob; requires logits"),
+  "carry_specs": NotApplicable(reason="streaming/sink bookkeeping (host/streaming.py); never touches the model"),
+  "dedup_specs": NotApplicable(reason="streaming/sink bookkeeping; never touches the model"),
+  "multi_state_temperature": NotApplicable(reason="reaches stage_set.logit_transform, not a bundle arg; only affects geometric_mean (logits.py:130,175)"),
+  "use_unified_driver": NotApplicable(reason="selects the dispatch path in kernel_dispatch, not a model-facing value"),
+  "tied_positions": NotApplicable(reason="requires pass_mode='inter' (specs.py:440-445); the campaign literal carries neither"),
+  "pass_mode": NotApplicable(reason="paired with tied_positions; not carried by the manifest"),
+
+  # --- batching knobs: MUST be no-ops at the boundary (invariance, not change) ----------
+  "samples_batch_size": NotApplicable(reason="Vmap-vs-SafeMap tile size only (plan.py:171-244). MUST NOT change model-facing values -- assert invariance; a diff here would be the bug."),
+  "noise_batch_size": NotApplicable(reason="tile size only; see samples_batch_size"),
+  "temperature_batch_size": NotApplicable(reason="tile size only; see samples_batch_size"),
+
+  # --- host/IO knobs, no model surface ---------------------------------------------------
+  "topology": NotApplicable(reason="parse-time input resolution"),
+  "model": NotApplicable(reason="NMR model index chosen at parse time; not carried by the manifest literal"),
+  "altloc": NotApplicable(reason="altloc chosen at parse time; not carried by the manifest literal"),
+  "cache_path": NotApplicable(reason="host-side cache location; no model surface, not in the manifest literal"),
+  "output_dir": NotApplicable(reason="host-side output location; campaign uses output_h5_path"),
+  "max_buffer_size": NotApplicable(reason="host-side streaming buffer"),
+  "overwrite_cache": NotApplicable(reason="host-side cache policy"),
+  "max_length": NotApplicable(reason="parse/truncation policy"),
+  "truncation_strategy": NotApplicable(reason="parse/truncation policy"),
+  "host_resource_allocation_strategy": NotApplicable(reason="host resource policy"),
+  "ram_budget_mb": NotApplicable(reason="host resource policy"),
+  "max_workers": NotApplicable(reason="host resource policy"),
+  "n_devices": NotApplicable(reason="host resource policy"),
+  "use_preprocessed": NotApplicable(reason="dataset source selection"),
+  "preprocessed_index_path": NotApplicable(reason="dataset source selection"),
+  "split": NotApplicable(reason="dataset split selection; inference default, not in the manifest literal"),
+  "noise": NotApplicable(reason="unified FeatureNoiseBundle list; the campaign carries the legacy backbone_noise scalar instead"),
+
+  # --- deprecated back-compat ------------------------------------------------------------
+  "backbone_noise_mode": NotApplicable(reason="deprecated; merged into the noise bundle at specs.py:330-352"),
+  "estat_noise": NotApplicable(reason="deprecated; merged into the noise bundle, specs.py:355-380"),
+  "estat_noise_mode": NotApplicable(reason="deprecated; merged into the noise bundle"),
+  "vdw_noise": NotApplicable(reason="deprecated; merged into the noise bundle, specs.py:382-407"),
+  "vdw_noise_mode": NotApplicable(reason="deprecated; merged into the noise bundle"),
+
+  # --- cannot cross the JSON boundary ----------------------------------------------------
+  "decoding_order_fn": NonSerializable(reason="callable; in _NON_JSON_ROOT_FIELDS (spec_json.py:99-108). Also never forwarded to _sample_batch."),
+  "encoding_fusion": NonSerializable(reason="callable; _NON_JSON_ROOT_FIELDS"),
+  "decoding_fusion": NonSerializable(reason="callable; _NON_JSON_ROOT_FIELDS"),
+  "foldcomp_database": NonSerializable(reason="live object; _NON_JSON_ROOT_FIELDS"),
+  "conformational_states": NonSerializable(reason="raises SpecJSONEncodeError when set"),
+
+  # --- internals --------------------------------------------------------------------------
+  "run_spec": Internal(reason="init=False; built in __post_init__, specs.py:319"),
+  "_run_spec_synced": Internal(reason="init=False guard flag"),
+}

--- a/tests/host/knob_observations.py
+++ b/tests/host/knob_observations.py
@@ -82,21 +82,48 @@ class Internal(Verdict):
 # today (proving the harness detects real bugs) and, once fixed, XPASS -> red build,
 # forcing the marker's removal. Both directions guarded, permanently.
 # ---------------------------------------------------------------------------
-KNOWN_BROKEN_AT_A17: dict[str, str] = {
-  "fixed_mask": "occurrence #7 -- not in the manifest literal; --fixed-policies never resolves to positions",
-  "fixed_positions": "occurrence #7 -- same; also a mask alias, not indices (runner.py:103 misdocuments it)",
-  "fixed_tokens": "occurrence #7 -- same",
-  "state_position_map": "occurrence #8 -- on the spec + spec_json whitelist, absent from campaign.py entirely",
-  "multi_state_strategy": "silently reverts to arithmetic_mean; row hash records the request, falsely implying it was honored",
-  "state_weights": "not in the manifest literal; --state-weight-profiles never resolves a name to weights (occurrence #10)",
-  "bias": "not in the manifest literal",
-  "tie_group_map": "not in the manifest literal",
-  "structure_mapping": "not in the manifest literal",
+# CLOSED by S1a's field-driven manifest write. All twelve are gone from this set because they
+# now genuinely survive the manifest -- verified by the suite going red (XPASS) until removed.
+#
+# Kept as a record rather than deleted: these twelve are what the audit was for, and the empty
+# dict below is the claim "the manifest-drop class no longer exists". If any regresses, its Tier
+# A test fails outright -- no marker to hide behind.
+CLOSED_BY_S1A: tuple[str, ...] = (
+  "fixed_mask",            # occurrence #7 -- the blocker; no residue was ever held fixed
+  "fixed_positions",       # occurrence #7
+  "fixed_tokens",          # occurrence #7
+  "state_position_map",    # occurrence #8 -- found during this audit
+  "multi_state_strategy",  # silently reverted to arithmetic_mean while the row hash claimed otherwise
+  "state_weights",         # occurrence #10
+  "bias",
+  "tie_group_map",
+  "structure_mapping",
+  "ligand_mpnn_use_side_chain_context",  # manifest hop only; model hop still broken -- see TIER B
+  "use_electrostatics",                  # ditto
+  "use_vdw",                             # ditto
+)
+
+# Tier A: does the caller's value survive plan -> manifest JSON -> reconstructed spec?
+# Empty after S1a. A new entry here means the manifest-drop class has returned.
+KNOWN_BROKEN_TIER_A: dict[str, str] = {}
+
+# Tier B: does it reach the MODEL? Deliberately NOT emptied by S1a.
+#
+# These three are broken in TWO places -- dropped by the manifest AND never forwarded at
+# prep.py:133,140 -> load_model. S1a fixed only the first. Their Tier A tests now pass, which is
+# exactly the false green this split exists to prevent: 12 markers clearing does not mean these
+# knobs work. They reach the manifest and die at the model boundary. Cleared by S3, not S1.
+KNOWN_BROKEN_TIER_B: dict[str, str] = {
   "ligand_mpnn_use_side_chain_context": (
-    "occurrence #6 -- absent from the manifest AND not forwarded prep.py:133,140 -> load_model"
+    "occurrence #6 -- survives the manifest after S1a, but prep.py:133,140 still never forward "
+    "it to load_model, so the model is built with sidechains off regardless. Cleared by S3."
   ),
-  "use_electrostatics": "not forwarded to load_model at prep.py:133,140 (contrast trainer.py:159-164 which does)",
-  "use_vdw": "same as use_electrostatics",
+  "use_electrostatics": (
+    "occurrence #11 -- forwarded to the DATASET (prep.py:111) but never to load_model, so "
+    "physics_feature_dim stays checkpoint-name-derived (contrast trainer.py:159-164, which does "
+    "forward it). Cleared by S3."
+  ),
+  "use_vdw": "occurrence #11 -- same as use_electrostatics (prep.py:114 dataset only). Cleared by S3.",
 }
 
 

--- a/tests/host/knob_observations.py
+++ b/tests/host/knob_observations.py
@@ -107,24 +107,25 @@ CLOSED_BY_S1A: tuple[str, ...] = (
 # Empty after S1a. A new entry here means the manifest-drop class has returned.
 KNOWN_BROKEN_TIER_A: dict[str, str] = {}
 
-# Tier B: does it reach the MODEL? Deliberately NOT emptied by S1a.
+# Tier B: does it reach the MODEL? Empty after S3.
 #
-# These three are broken in TWO places -- dropped by the manifest AND never forwarded at
-# prep.py:133,140 -> load_model. S1a fixed only the first. Their Tier A tests now pass, which is
-# exactly the false green this split exists to prevent: 12 markers clearing does not mean these
-# knobs work. They reach the manifest and die at the model boundary. Cleared by S3, not S1.
-KNOWN_BROKEN_TIER_B: dict[str, str] = {
-  "ligand_mpnn_use_side_chain_context": (
-    "occurrence #6 -- survives the manifest after S1a, but prep.py:133,140 still never forward "
-    "it to load_model, so the model is built with sidechains off regardless. Cleared by S3."
-  ),
-  "use_electrostatics": (
-    "occurrence #11 -- forwarded to the DATASET (prep.py:111) but never to load_model, so "
-    "physics_feature_dim stays checkpoint-name-derived (contrast trainer.py:159-164, which does "
-    "forward it). Cleared by S3."
-  ),
-  "use_vdw": "occurrence #11 -- same as use_electrostatics (prep.py:114 dataset only). Cleared by S3.",
-}
+# Deliberately NOT emptied by S1a, and that split earned its keep. `ligand_mpnn_use_side_chain_context`,
+# `use_electrostatics` and `use_vdw` were broken in TWO places -- dropped by the manifest AND
+# never forwarded at prep.py -> load_model. S1a fixed only the first, at which point their Tier A
+# tests went green while the knobs still did nothing: the model was built with sidechains off and
+# physics_feature_dim checkpoint-name-derived, regardless of what the caller asked for. Twelve
+# markers clearing did not mean twelve knobs worked. A single-tier harness would have declared
+# victory here.
+#
+# S3 forwards all three (prep.py's model_conditioning dict). Removing their markers is what
+# proved it: each went XPASS(strict) -> FAILED first, then green once removed -- the fix forces
+# the marker off. That property only exists because these are declarative
+# `request.node.add_marker(pytest.mark.xfail(strict=True))`; the imperative `pytest.xfail()`
+# aborts the test body, so a test using it can NEVER XPASS and would have sat here lying
+# indefinitely.
+#
+# A new entry here means a knob reaches the manifest and dies at the model boundary.
+KNOWN_BROKEN_TIER_B: dict[str, str] = {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/host/knob_observations.py
+++ b/tests/host/knob_observations.py
@@ -198,8 +198,29 @@ OBSERVATIONS: dict[str, Verdict] = {
   "compute_pseudo_perplexity": NotApplicable(reason="requires return_logits=True, which campaign hardcodes off"),
   "return_decoding_orders": NotApplicable(reason="output-shape knob; not carried by the manifest and not a boundary arg"),
   "return_logit_fingerprint": NotApplicable(reason="output-shape knob; requires logits"),
-  "carry_specs": NotApplicable(reason="streaming/sink bookkeeping (host/streaming.py); never touches the model"),
-  "dedup_specs": NotApplicable(reason="streaming/sink bookkeeping; never touches the model"),
+  # CORRECTED 2026-07-15. These were declared NotApplicable("streaming/sink bookkeeping
+  # (host/streaming.py); never touches the model") -- a FABRICATED reason. They feed the
+  # PLANNER (host/plan.py:79-80,98-100: carry_names = {cs.axis_name for cs in carry_specs}).
+  # The fabrication survived because test_every_reason_cites_something checked reason LENGTH
+  # (>20 chars), not whether the citation resolved. An external architecture review caught it,
+  # not the test built to catch exactly this. Both are now fixed.
+  "carry_specs": NonSerializable(
+    reason=(
+      "list[CarrySpec]; CarrySpec.transition is a ScanTransition CALLABLE and .init holds JAX "
+      "arrays. spec_json's _to_json_value has no nested-dataclass branch, so encoding a non-None "
+      "value raises SpecJSONEncodeError rather than dropping it. Feeds the planner "
+      "(host/plan.py:79-80,98-100), so a campaign row genuinely cannot carry a Scan axis -- a "
+      "real limitation to surface, not bookkeeping to ignore."
+    ),
+  ),
+  "dedup_specs": NonSerializable(
+    reason=(
+      "list[DedupSpec]; its unique_indices/index_map/k would serialize, but dedup_fn/gather_fn "
+      "are optional callables and _to_json_value has no nested-dataclass branch -> "
+      "SpecJSONEncodeError. Feeds the planner (host/plan.py:80,99), so a campaign row cannot "
+      "carry a dedup axis."
+    ),
+  ),
   "multi_state_temperature": NotApplicable(reason="reaches stage_set.logit_transform, not a bundle arg; only affects geometric_mean (logits.py:130,175)"),
   "use_unified_driver": NotApplicable(reason="selects the dispatch path in kernel_dispatch, not a model-facing value"),
   "tied_positions": NotApplicable(reason="requires pass_mode='inter' (specs.py:440-445); the campaign literal carries neither"),

--- a/tests/host/test_comp534_plan_wiring.py
+++ b/tests/host/test_comp534_plan_wiring.py
@@ -13,6 +13,7 @@ import pytest
 
 from aminx.host.plan import InferencePlan, make_inference_plan
 from aminx.inference.logits import make_stage_set
+from aminx.run.spec import build_run_spec
 
 
 class DummyModel(eqx.Module):
@@ -27,6 +28,13 @@ class DummySpec:
     state_weights = None
     sampling_strategy = "temperature"
     temperature = [1.0]
+
+
+# make_inference_plan reads decode-relevant fields from spec.run_spec.sampling (260716, EPIC
+# #1541 P4) -- build_run_spec() already does getattr(spec, "field", default) for every field,
+# so it produces a correctly-shaped RunSpec from this minimal duck spec with no changes needed
+# to the attribute set above.
+DummySpec.run_spec = build_run_spec(DummySpec)
 
 
 def test_runner_imports_make_inference_plan():

--- a/tests/host/test_comp535_encode_decode.py
+++ b/tests/host/test_comp535_encode_decode.py
@@ -11,6 +11,7 @@ import pytest
 
 from aminx.host.plan import InferencePlan, InferenceComponents, make_inference_plan
 from aminx.inference.sample_autoregressive import SampleResult
+from aminx.run.spec import build_run_spec
 
 
 class DummyModel(eqx.Module):
@@ -24,6 +25,11 @@ class DummySpec:
     state_weights = None
     sampling_strategy = "temperature"
     temperature = [1.0]
+
+
+# See test_comp534_plan_wiring.py's identical comment: make_inference_plan reads
+# spec.run_spec.sampling.* (260716, EPIC #1541 P4); build_run_spec() handles any duck spec.
+DummySpec.run_spec = build_run_spec(DummySpec)
 
 
 _DUMMY_SAMPLE_RESULT = SampleResult(

--- a/tests/host/test_comp536_campaign_manifest.py
+++ b/tests/host/test_comp536_campaign_manifest.py
@@ -71,11 +71,18 @@ class DummySpec:
 
 
 def _make_row(**kwargs):
-    """Helper: build a minimal valid manifest row dict."""
+    """Helper: build a minimal valid manifest row dict.
+
+    `fixed_policy` defaults to "none" -- fixing nothing -- because a row that NAMES an arm must
+    also CARRY that arm's mask in its sampling_spec, and a minimal row has no spec. The old
+    default was "catalytic_triad", i.e. the fixture claimed to fix the catalytic triad while
+    carrying nothing that could -- the production bug in miniature, baked into the helper that
+    every test in this file builds on.
+    """
     defaults = {
         "manifest_row_hash": "hash_abc123",
         "checkpoint_id": "ckpt_001",
-        "fixed_policy": "catalytic_triad",
+        "fixed_policy": "none",
         "state_weight_profile": "equal",
     }
     defaults.update(kwargs)
@@ -303,13 +310,9 @@ class TestValidateManifestRows:
     def test_passes_valid(self):
         rows = [
             _make_row(manifest_row_hash="h1"),
-            _make_row(
-                manifest_row_hash="h2", fixed_policy="active_site"
-            ),
+            _make_row(manifest_row_hash="h2", fixed_policy="none"),
         ]
-        validate_manifest_rows(
-            rows, required_fixed_policies=("catalytic_triad", "active_site")
-        )
+        validate_manifest_rows(rows)
 
     def test_missing_hash_raises(self):
         with pytest.raises(ValueError, match="manifest_row_hash"):
@@ -345,23 +348,40 @@ class TestValidateManifestRows:
         with pytest.raises(ValueError, match="state_weight_profile"):
             validate_manifest_rows([_make_row(state_weight_profile="")])
 
-    def test_missing_required_policy_raises(self):
-        rows = [_make_row(manifest_row_hash="h1")]  # only catalytic_triad
-        with pytest.raises(ValueError):
-            validate_manifest_rows(
-                rows, required_fixed_policies=("catalytic_triad", "active_site")
-            )
+    def test_a_row_naming_an_arm_must_carry_that_arm_s_mask(self):
+        """Replaces the deleted `required_fixed_policies` check, which could never fail.
 
-    def test_all_required_policies_present(self):
+        The old check did `set(required) - {row["fixed_policy"] for row in rows}` while the
+        planner passed it the very tuple its own loop had just consumed -- it compared the
+        planner's output against the planner's input. It was green for the entire life of the
+        decorative-policy bug. This checks a row against ITSELF instead: claim an arm, carry a
+        mask. That is a claim the planner can actually get wrong, and did, for 882/882 beads.
+        """
+        rows = [_make_row(manifest_row_hash="h1", fixed_policy="catalytic_triad")]
+        with pytest.raises(ValueError, match="no fixed_mask"):
+            validate_manifest_rows(rows)
+
+    def test_a_row_carrying_a_real_mask_passes(self):
         rows = [
-            _make_row(manifest_row_hash="h1"),
             _make_row(
-                manifest_row_hash="h2", fixed_policy="active_site"
+                manifest_row_hash="h1",
+                fixed_policy="catalytic_triad",
+                sampling_spec={"fixed_mask": [0, 1, 0, 1]},
             ),
         ]
-        validate_manifest_rows(
-            rows, required_fixed_policies=("catalytic_triad", "active_site")
-        )
+        validate_manifest_rows(rows)
+
+    def test_an_all_zero_mask_is_not_a_mask(self):
+        """An all-zero mask freezes nothing, so claiming an arm with one is still a lie."""
+        rows = [
+            _make_row(
+                manifest_row_hash="h1",
+                fixed_policy="catalytic_triad",
+                sampling_spec={"fixed_mask": [0, 0, 0, 0]},
+            ),
+        ]
+        with pytest.raises(ValueError, match="no fixed_mask"):
+            validate_manifest_rows(rows)
 
     def test_empty_rows_valid(self):
         validate_manifest_rows([])
@@ -479,11 +499,17 @@ class TestIntegration:
                 designs_per_library_type=100,
                 samples_chunk_size=50,
                 output_root=tmpdir,
-                fixed_policies=("catalytic_triad", "active_site"),
+                fixed_arms=None,
                 state_weight_profiles=("equal",),
             )
-            # 2 policies × 1 profile × 2 ligand × 2 sidechain × ceil(100/50) chunks = 16
-            assert len(rows) == 16
+            # 1 arm ("none") × 1 profile × 2 ligand × 2 sidechain × ceil(100/50) chunks = 8.
+            #
+            # Was 16, because the default was ("catalytic_triad", "active_site") -- TWO policy
+            # arms whose sampling_specs were BYTE-IDENTICAL, since the policy never reached the
+            # spec. Half of every planned campaign was exact-duplicate work wearing a different
+            # label. The drop from 16 to 8 is that duplication being removed, not coverage
+            # being lost.
+            assert len(rows) == 8
             for row in rows:
                 assert "manifest_row_hash" in row
                 assert len(row["manifest_row_hash"]) == 64
@@ -506,7 +532,7 @@ class TestIntegration:
                 designs_per_library_type=50,
                 samples_chunk_size=25,
                 output_root=tmpdir,
-                fixed_policies=("catalytic_triad",),
+                fixed_arms=None,
                 state_weight_profiles=("equal",),
             )
             assert result == manifest_path.resolve()
@@ -531,7 +557,7 @@ class TestIntegration:
                     designs_per_library_type=10,
                     samples_chunk_size=10,
                     output_root=tmpdir,
-                    fixed_policies=("catalytic_triad",),
+                    fixed_arms=None,
                     state_weight_profiles=("equal",),
                 )
 

--- a/tests/host/test_comp_unified_encoder_fusion.py
+++ b/tests/host/test_comp_unified_encoder_fusion.py
@@ -35,6 +35,7 @@ from aminx.host.output_sinks import (
 )
 from aminx.host.plan import InferencePlan, InferenceComponents
 from aminx.inference.sample_autoregressive import SampleResult
+from aminx.run.spec import build_run_spec
 from aminx.run.specs import SamplingSpecification
 from aminx.types.bundles import EncoderOutput
 from aminx.types.stages import ConditionalDecodeStep, StageSet
@@ -267,6 +268,7 @@ def test_make_inference_plan_wires_fusion_when_avg():
     spec.multi_state_temperature = 1.0
     spec.state_weights = None
     spec.sampling_strategy = "temperature"
+    spec.run_spec = build_run_spec(spec)
 
     with (
         patch("aminx.inference.encode.make_encode_fn", return_value=MagicMock()),
@@ -300,6 +302,7 @@ def test_make_inference_plan_no_fusion_when_no_avg():
     spec.multi_state_temperature = 1.0
     spec.state_weights = None
     spec.sampling_strategy = "temperature"
+    spec.run_spec = build_run_spec(spec)
 
     with (
         patch("aminx.inference.encode.make_encode_fn", return_value=MagicMock()),
@@ -728,6 +731,7 @@ def test_ste_routes_via_stage_set():
     spec.multi_state_temperature = 1.0
     spec.state_weights = None
     spec.sampling_strategy = "straight_through"
+    spec.run_spec = build_run_spec(spec)
 
     with (
         patch("aminx.inference.encode.make_encode_fn", return_value=MagicMock()),

--- a/tests/host/test_decode_path_differential.py
+++ b/tests/host/test_decode_path_differential.py
@@ -1,0 +1,242 @@
+"""Decode-path completeness + differential suite (260716, EPIC #1541 P4, following aminx#110).
+
+Two concerns, both about the SAME root cause: `make_inference_plan` (the single-structure/
+scoring path) and `sample_multistate_poe_bead` (the genuine multi-state PoE path) each used to
+independently decide which decode class to build, with nothing forcing agreement -- that's how
+aminx#110 happened (fixed_mask/temperature/random_seed/num_samples were all silently inert on
+the ConditionalDecode path because no branch ever built AutoregressiveDecode there).
+
+1. TestRunSpecCompleteness -- static/AST guard: catches a future silent reversion to flat
+   getattr(spec, ...) reads for fields that now have a RunSpec.sampling home. This is exactly
+   the class of regression that let aminx#110 happen undetected in the first place, and the
+   same class of regression that deleted 3 RunSpec sub-configs (`dd0e952`) as incidental
+   cleanup during an unrelated refactor with nothing to catch it.
+
+2. TestDecodePathDifferential -- live, real-checkpoint two-armed differentials (same pattern
+   proven throughout the 260716 audit) re-verifying the actual fix, marked `slow` since they
+   load a real proteinmpnn_v_48_020 checkpoint and are not cheap enough for default CI.
+
+Local compute note: every real-model test here uses max_length=128 (>= 1ubq's ~76-residue
+native length) to avoid aminx's own truncation_strategy="random_crop" default silently firing
+on a too-small max_length -- exactly the confound that produced a false "sample() has unseeded
+non-determinism" signal during this same audit before being traced to its real cause.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from dataclasses import fields as dc_fields
+
+import jax
+import numpy as np
+import pytest
+
+from aminx.host.plan import make_inference_plan
+from aminx.run.spec import SamplingConfig
+
+pytestmark = pytest.mark.slow
+
+_MAX_LENGTH = 128
+_STRUCTURE = "tests/data/1ubq.pdb"
+_CHECKPOINT = "proteinmpnn_v_48_020"
+
+
+class TestRunSpecCompleteness:
+  """Guard against silently reverting to flat spec reads for RunSpec-migrated fields."""
+
+  def test_make_inference_plan_does_not_flat_read_migrated_fields(self) -> None:
+    """make_inference_plan must read migrated fields via spec.run_spec.sampling, not flat.
+
+    AST-scans the function source for `getattr(spec, "<field>", ...)` calls naming any field
+    that RunSpec.SamplingConfig now carries (added 260716) -- a flat read of one of these is
+    not a bug in the traditional sense (it would likely still work, since flat and run_spec
+    values agree today), but it is exactly the kind of silent divergence-in-waiting that
+    produced aminx#110: two code paths reading the "same" value through different routes with
+    nothing keeping them honest if one drifts.
+    """
+    migrated_fields = {f.name for f in dc_fields(SamplingConfig)}
+
+    source = inspect.getsource(make_inference_plan)
+    tree = ast.parse(source)
+
+    flat_reads = []
+    for node in ast.walk(tree):
+      if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and len(node.args) >= 2
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "spec"
+        and isinstance(node.args[1], ast.Constant)
+        and node.args[1].value in migrated_fields
+      ):
+        flat_reads.append(node.args[1].value)
+
+    assert not flat_reads, (
+      f"make_inference_plan reads {flat_reads} via flat getattr(spec, ...) despite these "
+      f"fields having a RunSpec.sampling home -- read spec.run_spec.sampling.<field> instead. "
+      f"This is exactly the silent-regression pattern that let aminx#110 go undetected."
+    )
+
+  def test_sampling_strategy_is_a_real_runspec_field(self) -> None:
+    """sampling_strategy -- the field that decides which decode class gets built at all --
+    must never silently disappear from RunSpec again. Before 260716 it was never migrated in
+    the first place (a genuine blind spot in the original RS-1 inventory, not a deliberate
+    decision); after 260716's fix, its disappearance would silently break resolve_decode_mode
+    for every caller. A plain field-presence assertion, not a differential -- cheap and
+    always-on.
+    """
+    field_names = {f.name for f in dc_fields(SamplingConfig)}
+    assert "sampling_strategy" in field_names, (
+      "RunSpec.SamplingConfig lost its sampling_strategy field -- resolve_decode_mode "
+      "(host/plan.py) depends on spec.run_spec.sampling.sampling_strategy existing; without "
+      "it, decode-mode resolution has no signal to route STEMode at all."
+    )
+
+
+def _sample_sequences(*, num_samples: int, temperature: float, random_seed: int, **kwargs):
+  from aminx.host.runner import sample
+
+  r = sample(
+    inputs=[_STRUCTURE],
+    checkpoint_id=_CHECKPOINT,
+    num_samples=num_samples,
+    temperature=temperature,
+    random_seed=random_seed,
+    max_length=_MAX_LENGTH,
+    **kwargs,
+  )
+  return np.asarray(r["sequences"]).reshape(num_samples, -1)[:, :_MAX_LENGTH]
+
+
+class TestDecodePathDifferential:
+  """Live re-verification of the aminx#110 fix on the ConditionalDecode (sample()) path.
+
+  Mutation-tested: reverting host/plan.py's resolve_decode_mode call to the pre-fix
+  `decode_mode = ConditionalMode()` (unconditional) makes every test in this class fail --
+  confirmed manually before landing this file, per this project's standing rule that a test
+  which cannot fail is worse than no test.
+  """
+
+  def test_fixed_mask_holds_on_sample(self) -> None:
+    from aminx.utils.aa_convert import MPNN_ALPHABET
+
+    w_idx = MPNN_ALPHABET.index("W")
+    mask = np.zeros(_MAX_LENGTH, dtype=np.float32)
+    mask[:20] = 1.0
+    tok = np.zeros(_MAX_LENGTH, dtype=np.int32)
+    tok[:20] = w_idx
+
+    masked = _sample_sequences(
+      num_samples=2, temperature=0.5, random_seed=0, fixed_mask=mask, fixed_tokens=tok,
+    )
+    unmasked = _sample_sequences(num_samples=2, temperature=0.5, random_seed=0)
+
+    frac_w_masked = float((masked[:, :20] == w_idx).mean())
+    frac_w_unmasked = float((unmasked[:, :20] == w_idx).mean())
+    assert frac_w_masked > 0.9, (
+      f"fixed_mask did not hold on sample(): only {frac_w_masked:.2f} of the frozen region "
+      f"was the declared token. aminx#110 regression."
+    )
+    assert frac_w_unmasked < 0.3, (
+      "unmasked control unexpectedly high at the same positions -- background W rate should "
+      "be low; if this fires, the differential's own control arm is broken, not just the fix."
+    )
+    assert not np.array_equal(masked, unmasked), "masked and unmasked arms must not be identical"
+
+  def test_num_samples_produces_real_diversity(self) -> None:
+    seqs = _sample_sequences(num_samples=4, temperature=0.5, random_seed=0)
+    assert not bool(np.all(seqs == seqs[0])), (
+      "all 4 samples from one sample() call are byte-identical -- ConditionalDecode's "
+      "no-stochastic-sampling regression (aminx#110 escalation) is back."
+    )
+
+  def test_random_seed_changes_output(self) -> None:
+    outputs = [
+      _sample_sequences(num_samples=1, temperature=0.5, random_seed=seed)[0]
+      for seed in (0, 1, 2)
+    ]
+    assert not all(np.array_equal(outputs[0], o) for o in outputs[1:]), (
+      "random_seed has no effect on sample() output -- aminx#110 escalation regression."
+    )
+
+  def test_bias_affects_sample_output(self) -> None:
+    from aminx.utils.aa_convert import MPNN_ALPHABET
+
+    w_idx = MPNN_ALPHABET.index("W")
+    bias_off = np.zeros((_MAX_LENGTH, 21), dtype=np.float32)
+    bias_on = np.zeros((_MAX_LENGTH, 21), dtype=np.float32)
+    bias_on[:, w_idx] = 50.0
+
+    off = _sample_sequences(num_samples=1, temperature=0.5, random_seed=0, bias=bias_off)
+    on = _sample_sequences(num_samples=1, temperature=0.5, random_seed=0, bias=bias_on)
+    assert float((on == w_idx).mean()) > float((off == w_idx).mean()), (
+      "bias had no effect on sample() output."
+    )
+
+  def test_tie_group_map_ties_positions_on_sample(self) -> None:
+    tie_map = np.arange(_MAX_LENGTH, dtype=np.int32)
+    tie_map[5] = tie_map[0]
+
+    untied = _sample_sequences(num_samples=1, temperature=0.5, random_seed=0)[0]
+    tied = _sample_sequences(
+      num_samples=1, temperature=0.5, random_seed=0, tie_group_map=tie_map,
+    )[0]
+    assert untied[0] != untied[5], "fixture assumption violated: positions 0/5 already equal untied"
+    assert tied[0] == tied[5], "tie_group_map did not force positions 0 and 5 to match"
+
+
+class TestCrossPathAgreement:
+  """The property that was structurally impossible to test before resolve_decode_mode existed:
+  do the two real decode paths agree on which DecodeMode a given sampling_strategy means?
+  """
+
+  def test_default_sampling_strategy_resolves_to_the_same_mode_class_on_both_paths(self) -> None:
+    from aminx.host.plan import resolve_decode_mode
+    from aminx.inference.decode.mode import AutoregressiveMode
+    from aminx.run.specs import SamplingSpecification
+
+    single_spec = SamplingSpecification(
+      inputs=[_STRUCTURE], checkpoint_id=_CHECKPOINT, max_length=_MAX_LENGTH,
+    )
+    multi_spec = SamplingSpecification(
+      inputs=[_STRUCTURE, _STRUCTURE],
+      checkpoint_id=_CHECKPOINT,
+      batch_size=2,
+      max_length=_MAX_LENGTH,
+    )
+
+    single_mode = resolve_decode_mode(single_spec.run_spec, purpose="sample")
+    multi_mode = resolve_decode_mode(multi_spec.run_spec, purpose="sample")
+
+    assert type(single_mode) is type(multi_mode), (
+      f"the same sampling_strategy resolved to different DecodeMode classes depending on "
+      f"whether the spec was single- or multi-state ({type(single_mode).__name__} vs "
+      f"{type(multi_mode).__name__}) -- exactly the divergence resolve_decode_mode exists "
+      f"to prevent."
+    )
+    assert isinstance(single_mode, AutoregressiveMode), (
+      f"purpose='sample' at the default sampling_strategy should resolve to AutoregressiveMode, "
+      f"got {type(single_mode).__name__}"
+    )
+
+  def test_straight_through_is_honestly_rejected_by_the_poe_path(self) -> None:
+    """sample_multistate_poe_bead has no STE-for-PoE implementation (out of scope, see the
+    260716 migration plan) -- it must raise, not silently sample via AutoregressiveMode anyway.
+    """
+    from aminx.run.specs import SamplingSpecification
+    from aminx.sampling.multistate_poe import sample_multistate_poe_bead
+
+    spec = SamplingSpecification(
+      inputs=[_STRUCTURE, _STRUCTURE],
+      checkpoint_id=_CHECKPOINT,
+      batch_size=2,
+      max_length=_MAX_LENGTH,
+      sampling_strategy="straight_through",
+      iterations=1,
+      learning_rate=0.1,
+    )
+    with pytest.raises(NotImplementedError, match="straight_through"):
+      sample_multistate_poe_bead(spec, jax.random.PRNGKey(0), 1)

--- a/tests/host/test_decode_path_differential.py
+++ b/tests/host/test_decode_path_differential.py
@@ -35,7 +35,11 @@ import pytest
 from aminx.host.plan import make_inference_plan
 from aminx.run.spec import SamplingConfig
 
-pytestmark = pytest.mark.slow
+# NOTE: no module-level `slow` marker. TestRunSpecCompleteness and the structural half of
+# TestCrossPathAgreement need no checkpoint and must run in DEFAULT CI -- they are the actual
+# regression guards. Only classes/tests that load a real checkpoint carry `slow` individually
+# (an earlier version of this file marked the whole module `slow`, which meant the guards never
+# ran by default at all -- caught by independent review before merge, not by CI).
 
 _MAX_LENGTH = 128
 _STRUCTURE = "tests/data/1ubq.pdb"
@@ -48,12 +52,20 @@ class TestRunSpecCompleteness:
   def test_make_inference_plan_does_not_flat_read_migrated_fields(self) -> None:
     """make_inference_plan must read migrated fields via spec.run_spec.sampling, not flat.
 
-    AST-scans the function source for `getattr(spec, "<field>", ...)` calls naming any field
-    that RunSpec.SamplingConfig now carries (added 260716) -- a flat read of one of these is
-    not a bug in the traditional sense (it would likely still work, since flat and run_spec
-    values agree today), but it is exactly the kind of silent divergence-in-waiting that
-    produced aminx#110: two code paths reading the "same" value through different routes with
-    nothing keeping them honest if one drifts.
+    AST-scans the function source for two flat-read shapes naming any field that
+    RunSpec.SamplingConfig now carries (added 260716): `getattr(spec, "<field>", ...)` calls
+    AND direct `spec.<field>` attribute access. Only a DIRECT `spec.<field>` is flagged --
+    `spec.run_spec.sampling.<field>` parses as nested Attribute nodes whose innermost `.value`
+    is `spec.run_spec.sampling` (an Attribute), not the bare `spec` Name, so the legitimate
+    access pattern this function is supposed to use is never a false positive here.
+
+    A flat read of one of these is not a bug in the traditional sense (it would likely still
+    work, since flat and run_spec values agree today), but it is exactly the kind of silent
+    divergence-in-waiting that produced aminx#110: two code paths reading the "same" value
+    through different routes with nothing keeping them honest if one drifts.
+
+    Known residual gap (documented, not fixed): an aliased access (`s = spec; s.field` or
+    `getattr(s, "field")`) would not be caught. Not exercised anywhere in this function today.
     """
     migrated_fields = {f.name for f in dc_fields(SamplingConfig)}
 
@@ -73,11 +85,19 @@ class TestRunSpecCompleteness:
         and node.args[1].value in migrated_fields
       ):
         flat_reads.append(node.args[1].value)
+      elif (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "spec"
+        and node.attr in migrated_fields
+      ):
+        flat_reads.append(node.attr)
 
     assert not flat_reads, (
-      f"make_inference_plan reads {flat_reads} via flat getattr(spec, ...) despite these "
-      f"fields having a RunSpec.sampling home -- read spec.run_spec.sampling.<field> instead. "
-      f"This is exactly the silent-regression pattern that let aminx#110 go undetected."
+      f"make_inference_plan reads {flat_reads} via a flat spec.<field>/getattr(spec, ...) read "
+      f"despite these fields having a RunSpec.sampling home -- read "
+      f"spec.run_spec.sampling.<field> instead. This is exactly the silent-regression pattern "
+      f"that let aminx#110 go undetected."
     )
 
   def test_sampling_strategy_is_a_real_runspec_field(self) -> None:
@@ -118,7 +138,11 @@ class TestDecodePathDifferential:
   `decode_mode = ConditionalMode()` (unconditional) makes every test in this class fail --
   confirmed manually before landing this file, per this project's standing rule that a test
   which cannot fail is worse than no test.
+
+  Loads a real proteinmpnn_v_48_020 checkpoint -- not cheap enough for default CI.
   """
+
+  pytestmark = pytest.mark.slow
 
   def test_fixed_mask_holds_on_sample(self) -> None:
     from aminx.utils.aa_convert import MPNN_ALPHABET
@@ -190,10 +214,47 @@ class TestDecodePathDifferential:
 
 class TestCrossPathAgreement:
   """The property that was structurally impossible to test before resolve_decode_mode existed:
-  do the two real decode paths agree on which DecodeMode a given sampling_strategy means?
+  the two real decode paths cannot diverge on which DecodeMode a given sampling_strategy means.
+
+  Note on an earlier version of this class (caught by independent review before merge): a test
+  here previously called `resolve_decode_mode` directly with two different RunSpecs and compared
+  the results -- that is TRIVIALLY true (it's the same pure function called twice) and does not
+  exercise either real call site, so it could never have caught a regression where one of the
+  two production call sites stopped calling the shared resolver. The structural test below
+  checks the actual property; the runtime test after it is kept as a narrower, honestly-named
+  check of the resolver's own behavior, not of cross-path agreement.
   """
 
-  def test_default_sampling_strategy_resolves_to_the_same_mode_class_on_both_paths(self) -> None:
+  def test_both_production_call_sites_use_the_shared_resolver(self) -> None:
+    """Structural proof, not a runtime coincidence: both make_inference_plan and
+    sample_multistate_poe_bead must literally call resolve_decode_mode. This is the actual
+    reason the two paths cannot diverge -- a future edit that reintroduces a hardcoded
+    ConditionalMode()/AutoregressiveMode() on either path (aminx#110's exact failure class)
+    fails this test immediately, with no checkpoint needed.
+    """
+    from aminx.host import plan as plan_module
+    from aminx.sampling import multistate_poe as poe_module
+
+    plan_source = inspect.getsource(plan_module.make_inference_plan)
+    assert "resolve_decode_mode(" in plan_source, (
+      "make_inference_plan no longer calls resolve_decode_mode -- it may have reverted to "
+      "hardcoding a DecodeMode directly, reopening aminx#110's exact failure class."
+    )
+
+    poe_source = inspect.getsource(poe_module.sample_multistate_poe_bead)
+    assert "resolve_decode_mode(" in poe_source, (
+      "sample_multistate_poe_bead no longer calls resolve_decode_mode -- it may have reverted "
+      "to hardcoding AutoregressiveMode() directly, the original divergence bug."
+    )
+
+  def test_resolver_is_insensitive_to_run_spec_shape(self) -> None:
+    """Narrower than the name of an earlier version of this test claimed: this checks that
+    resolve_decode_mode itself returns the same DecodeMode class for a single- and a
+    multi-state RunSpec at the same sampling_strategy/purpose -- a real property (the resolver
+    must not accidentally branch on state count), but NOT a test that the two production call
+    sites agree with each other (see test_both_production_call_sites_use_the_shared_resolver
+    for that). No checkpoint needed -- resolve_decode_mode only reads run_spec.sampling.*.
+    """
     from aminx.host.plan import resolve_decode_mode
     from aminx.inference.decode.mode import AutoregressiveMode
     from aminx.run.specs import SamplingSpecification
@@ -212,19 +273,23 @@ class TestCrossPathAgreement:
     multi_mode = resolve_decode_mode(multi_spec.run_spec, purpose="sample")
 
     assert type(single_mode) is type(multi_mode), (
-      f"the same sampling_strategy resolved to different DecodeMode classes depending on "
-      f"whether the spec was single- or multi-state ({type(single_mode).__name__} vs "
-      f"{type(multi_mode).__name__}) -- exactly the divergence resolve_decode_mode exists "
-      f"to prevent."
+      f"resolve_decode_mode returned different DecodeMode classes for a single- vs multi-state "
+      f"RunSpec at the same sampling_strategy/purpose ({type(single_mode).__name__} vs "
+      f"{type(multi_mode).__name__}) -- it must not branch on state count."
     )
     assert isinstance(single_mode, AutoregressiveMode), (
       f"purpose='sample' at the default sampling_strategy should resolve to AutoregressiveMode, "
       f"got {type(single_mode).__name__}"
     )
 
+  @pytest.mark.slow
   def test_straight_through_is_honestly_rejected_by_the_poe_path(self) -> None:
     """sample_multistate_poe_bead has no STE-for-PoE implementation (out of scope, see the
     260716 migration plan) -- it must raise, not silently sample via AutoregressiveMode anyway.
+
+    Loads a real checkpoint + parses a real structure before reaching the check (the guard sits
+    at the end of sample_multistate_poe_bead, after bundle construction) -- not cheap, unlike
+    the rest of this class.
     """
     from aminx.run.specs import SamplingSpecification
     from aminx.sampling.multistate_poe import sample_multistate_poe_bead

--- a/tests/host/test_fixed_arms.py
+++ b/tests/host/test_fixed_arms.py
@@ -40,6 +40,7 @@ task_id: 260715_aminx-campaign-control-knob-audit
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
@@ -51,7 +52,19 @@ from aminx.run.specs import SamplingSpecification
 pytestmark = pytest.mark.knob_differential
 
 _CKPT = "ligandmpnn_v_32_020_25"
-_L = 512  # CAMPAIGN_MAX_LENGTH -- the spec-boundary length, not the native 214
+
+# `SamplingSpecification.max_length`'s default (run/specs.py:270). The mask must match the
+# PARSED structure's padded length -- `_prepare_fixed_controls` takes seq_len from
+# `batched_ensemble.coordinates.shape[1]`, and `prep.py:117` pads the dataset to
+# `spec.max_length`. `campaign plan` exposes neither --max-length nor --truncation-strategy,
+# so a campaign always runs this default and 512 is always right *there*.
+#
+# An earlier version of this comment called it CAMPAIGN_MAX_LENGTH. **No such constant exists
+# anywhere in aminx** -- the name was carried out of a stale plan and written here as though
+# it were real. It is an ordinary spec field with an ordinary default. Left as a note because
+# an invented citation in a test is exactly the kind of confident-looking wrong thing this
+# audit keeps finding.
+_L = 512
 _TRIAD = (38, 73, 143)  # canonical indices: His46/Asp81/Cys151 == tev_num - 8
 
 
@@ -91,6 +104,57 @@ def test_arm_mask_reaches_the_sampling_spec() -> None:
   )
   got = np.asarray(spec["fixed_mask"])
   assert sorted(np.nonzero(got)[0].tolist()) == list(_TRIAD)
+
+
+def test_the_arm_s_mask_SURVIVES_TO_THE_WORKER_not_just_into_json() -> None:
+  """Plan -> manifest JSON -> reconstructed spec -> `_prepare_fixed_controls`. End to end.
+
+  **This is the test cycle 1 should have had and did not.** Every other assertion here stops
+  at the manifest JSON, which proves the planner wrote a key -- not that the mask is intact
+  and correctly shaped by the time anything could act on it. "It's in the JSON" was the same
+  confidence level as "the row says catalytic_triad", which is what the whole epic is about.
+
+  Shape is the live risk: `_prepare_fixed_controls` derives seq_len from the PARSED
+  structure's padded length and hard-errors on a mismatch, so a mask sized against the wrong
+  assumption fails here and nowhere earlier.
+  """
+  import jax.numpy as jnp
+
+  from aminx.host._sampling_helper import _prepare_fixed_controls
+  from aminx.run.spec_json import _coerce_field_value
+  from aminx.utils.data_structures import Protein
+
+  rows = _plan(fixed_arms={"catalytic_triad": _mask(*_TRIAD)})
+
+  # The worker's REAL reconstruction path (campaign.py:838-856): coerce the JSON payload
+  # back through the plain constructor. Not a stand-in for it.
+  payload = {
+    k: _coerce_field_value(SamplingSpecification, k, v)
+    for k, v in dict(rows[0]["sampling_spec"]).items()
+  }
+  spec = SamplingSpecification(**payload)
+
+  ensemble = Protein(
+    coordinates=jnp.zeros((1, _L, 4, 3), dtype=jnp.float32),
+    aatype=jnp.zeros((1, _L), dtype=jnp.int32),
+    atom_mask=jnp.ones((1, _L, 37), dtype=jnp.float32),
+    residue_index=jnp.arange(_L, dtype=jnp.int32)[None, :],
+    chain_index=jnp.zeros((1, _L), dtype=jnp.int32),
+    mask=jnp.ones((1, _L), dtype=jnp.float32),
+    mapping=None,
+  )
+  # fixed_tokens must accompany the mask or the Alanine guard refuses the pair -- freezing
+  # without saying to what locks every frozen position to token 0 (Ala).
+  spec = replace(spec, fixed_tokens=np.zeros(_L, dtype=np.int32))
+
+  fixed_mask, _tokens = _prepare_fixed_controls(spec, batched_ensemble=ensemble)
+
+  frozen = sorted(np.nonzero(np.asarray(fixed_mask)[0])[0].tolist())
+  assert frozen == list(_TRIAD), (
+    f"The arm's mask did not survive to the worker: frozen positions are {frozen}, expected "
+    f"{list(_TRIAD)}. It reached the manifest but not the thing that acts on it -- which is "
+    f"the entire failure mode this audit exists to close."
+  )
 
 
 def test_arm_label_still_travels_for_provenance() -> None:
@@ -157,3 +221,51 @@ def test_the_old_decorative_flag_is_a_hard_error() -> None:
   """
   with pytest.raises(TypeError, match="fixed_polic"):
     _plan(fixed_policies=("catalytic_triad",))
+
+
+# ---------------------------------------------------------------------------
+# The evidence channel: can a reader PROVE what was frozen, after the fact?
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_outputs_carry_the_mask_and_name_their_alphabet() -> None:
+  """`fixed_mask` must reach the OUTPUT, not just the model.
+
+  Before this, the mask reached the model and vanished: no `fixed_mask` anywhere in `io/` or
+  any sink. So a finished campaign could not be interrogated -- 882/882 rows, every done
+  marker valid, every content digest intact, and not one residue held. The completion record
+  was perfect precisely because completion was the only thing recorded.
+  """
+  from aminx.host._sampling_helper import fixed_provenance_outputs
+
+  mask = _mask(*_TRIAD)
+  spec = SamplingSpecification(
+    inputs=["ref.pdb"],
+    checkpoint_id=_CKPT,
+    fixed_mask=mask,
+    fixed_tokens=np.zeros(_L, dtype=np.int32),
+  )
+  arrays, attrs = fixed_provenance_outputs(spec, seq_len=_L)
+
+  assert sorted(np.nonzero(arrays["fixed_mask"])[0].tolist()) == list(_TRIAD)
+  assert attrs["n_fixed"] == len(_TRIAD)
+  # The alphabet travels as DATA. The consumer-side bug this audit found was a rename
+  # stripping an `_af` suffix and taking the convention with it; a rename cannot strip a value.
+  assert attrs["fixed_tokens_alphabet"] == "MPNN"
+
+
+def test_an_unfixed_row_says_so_rather_than_staying_silent() -> None:
+  """Nothing-fixed must be a WRITTEN zero, not an absent key.
+
+  "No mask" and "a mask that froze nothing" are the same silence to a reader, and this whole
+  epic is what silence costs. n_fixed == 0 is a fact someone can see in the metadata and act
+  on; a missing key is something they have to notice.
+  """
+  from aminx.host._sampling_helper import fixed_provenance_outputs
+
+  spec = SamplingSpecification(inputs=["ref.pdb"], checkpoint_id=_CKPT)
+  arrays, attrs = fixed_provenance_outputs(spec, seq_len=_L)
+
+  assert "fixed_mask" in arrays, "an unfixed row must still SAY it fixed nothing"
+  assert arrays["fixed_mask"].shape == (_L,)
+  assert attrs["n_fixed"] == 0

--- a/tests/host/test_fixed_arms.py
+++ b/tests/host/test_fixed_arms.py
@@ -1,0 +1,159 @@
+"""A fixed policy must reach the model, or it is decoration.
+
+`--fixed-policies catalytic_triad` was DECORATIVE for the life of the flag. The planner wrote
+the policy NAME into the manifest row and never into the spec:
+
+    for fixed_policy in fixed_policies:            # campaign.py:612
+        spec_variant = replace(base_spec, ...)     # <- fixed_policy NEVER touches this
+        row = build_manifest_row(..., fixed_policy=fixed_policy)   # -> row dict only
+        row["sampling_spec"] = campaign_sampling_spec_payload(spec_variant, ...)
+
+The worker reconstructs from `row["sampling_spec"]` alone, so the policy could not reach it.
+Consequence: **no residue was ever held fixed in any produced design** -- 882/882 beads of a
+real library, silently violating a locked preregistration.
+
+The gate that should have caught it could not:
+
+    policies_seen = {row["fixed_policy"] for row in rows}      # campaign.py:210
+    missing = set(required_fixed_policies) - policies_seen
+
+`campaign.py:671` passes the same tuple the loop consumed, so this compares the planner's
+output against the planner's own input. It cannot fail. It checked that a *string label was
+present* -- nothing about whether a residue was fixed.
+
+**Why the policy now carries its own referent.** A bare name is unresolvable by construction:
+aminx cannot know that `catalytic_triad` means canonical [38, 73, 143] for TEV, or that
+`active_site` is an 84-residue shell -- those live in the consumer's own bundle. That is why
+the shipped default (`catalytic_triad,active_site`) was unresolvable out of the box. A
+resolver callback is not an option either: callables cannot cross the manifest's JSON
+boundary, and `spec_partition._assert_no_callable_knobs` refuses them outright.
+
+**The mask is 1-D, in the canonical reference frame.** Not per-state. `bundles.py:138` types
+it `Float[Array, L]` while `state_position_map` beside it is `"S L"`; `multistate_poe.py`
+RAISES on a genuinely per-state mask; decode broadcasts it over the group axis because one
+sequence is sampled and a position is either designed or it isn't. Cross-state index shifts
+(canonical 38 is His in 1LVB but Ser in 1LVM) are what `state_position_map` is for, and the
+consumer already computes and injects it.
+
+task_id: 260715_aminx-campaign-control-knob-audit
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from aminx.host.campaign import plan_campaign_manifest
+from aminx.run.specs import SamplingSpecification
+
+pytestmark = pytest.mark.knob_differential
+
+_CKPT = "ligandmpnn_v_32_020_25"
+_L = 512  # CAMPAIGN_MAX_LENGTH -- the spec-boundary length, not the native 214
+_TRIAD = (38, 73, 143)  # canonical indices: His46/Asp81/Cys151 == tev_num - 8
+
+
+def _mask(*positions: int) -> np.ndarray:
+  m = np.zeros(_L, dtype=np.float32)
+  for p in positions:
+    m[p] = 1.0
+  return m
+
+
+def _plan(**kwargs: Any) -> list[dict[str, Any]]:
+  """Drive the REAL planner. Not a reconstruction of it."""
+  return plan_campaign_manifest(
+    base_spec=SamplingSpecification(inputs=["ref.pdb"], checkpoint_id=_CKPT),
+    campaign_id="fixed-arms",
+    output_root="/tmp/fixed-arms",
+    designs_per_library_type=1,
+    samples_chunk_size=1,
+    **kwargs,
+  )
+
+
+def test_arm_mask_reaches_the_sampling_spec() -> None:
+  """THE bug. The arm's mask must land in `sampling_spec`, which is all the worker reads.
+
+  This is the whole epic in one assertion. Before the fix the planner produced a row whose
+  `sampling_spec` had `fixed_mask: None` while the row cheerfully advertised
+  `fixed_policy: "catalytic_triad"` -- and every downstream check looked at the label.
+  """
+  rows = _plan(fixed_arms={"catalytic_triad": _mask(*_TRIAD)})
+
+  spec = rows[0]["sampling_spec"]
+  assert spec.get("fixed_mask") is not None, (
+    "The arm's mask did not reach sampling_spec. The worker reconstructs its spec from "
+    "sampling_spec alone, so a mask that is not here does not exist as far as the model is "
+    "concerned -- which is exactly how 882/882 beads shipped with nothing held fixed."
+  )
+  got = np.asarray(spec["fixed_mask"])
+  assert sorted(np.nonzero(got)[0].tolist()) == list(_TRIAD)
+
+
+def test_arm_label_still_travels_for_provenance() -> None:
+  """The label is still written -- it just is no longer the ONLY thing written."""
+  rows = _plan(fixed_arms={"catalytic_triad": _mask(*_TRIAD)})
+  assert rows[0]["fixed_policy"] == "catalytic_triad"
+
+
+def test_distinct_arms_produce_DISTINCT_specs() -> None:
+  """Two arms must differ in the spec, not merely in the label.
+
+  Today they do not: every policy produces a byte-identical `sampling_spec`, so the grid axis
+  manufactures exact duplicates -- the same defect the consumer already found on the
+  ligand x sidechain axis (3 of every 4 groups identical after patching). A grid whose arms
+  are indistinguishable is not a grid; it is the same run counted twice.
+  """
+  rows = _plan(
+    fixed_arms={"catalytic_triad": _mask(*_TRIAD), "wider": _mask(*_TRIAD, 100, 101)},
+  )
+
+  by_label = {r["fixed_policy"]: np.asarray(r["sampling_spec"]["fixed_mask"]) for r in rows}
+  assert set(by_label) == {"catalytic_triad", "wider"}
+  assert not np.array_equal(by_label["catalytic_triad"], by_label["wider"]), (
+    "Two arms produced identical fixed_masks. The arms are not distinct, so the grid is "
+    "generating duplicate work and calling it diversity."
+  )
+
+
+def test_no_arms_means_design_everything_NOT_zero_rows() -> None:
+  """Absent arms must yield a full row-set with nothing fixed. Never zero rows.
+
+  `fixed_policies=()` used to silently produce ZERO rows: the policy loop was the outermost
+  one, so an empty tuple meant the body never executed and `rows` stayed `[]`. Then
+  `validate_manifest_rows(rows=[], required_fixed_policies=())` skipped every check (both
+  loops iterate nothing; the final check is gated behind `if required_fixed_policies:`) and
+  returned cleanly. An empty manifest is not a plan -- it is a no-op wearing a plan's clothes.
+
+  "Fix nothing" is the only default aminx can honestly ship: it cannot know any protein's
+  catalytic triad, so fixing must be an explicit opt-in.
+  """
+  rows = _plan()
+  assert rows, "No arms produced ZERO rows. An empty manifest must never be a silent success."
+  assert rows[0]["sampling_spec"].get("fixed_mask") is None
+  assert rows[0]["fixed_policy"] == "none"
+
+
+def test_explicitly_empty_arms_raises() -> None:
+  """`fixed_arms={}` states an intent that cannot be honoured, so it must not be guessed at.
+
+  Distinct from `fixed_arms=None` (above), which means "I did not ask for any fixing".
+  Passing an empty mapping means "here are my arms" followed by no arms -- a contradiction.
+  Silently treating it as "design everything" is how the original zero-rows bug read.
+  """
+  with pytest.raises(ValueError, match="fixed_arms"):
+    _plan(fixed_arms={})
+
+
+def test_the_old_decorative_flag_is_a_hard_error() -> None:
+  """`fixed_policies=` must fail loudly, not be quietly ignored or silently accepted.
+
+  Accepting a bare policy name and doing nothing with it IS the original sin. A deprecation
+  warning would preserve the exact behaviour that voided a library, so this raises instead --
+  and the message has to name the replacement, or we have only moved the confusion.
+  """
+  with pytest.raises(TypeError, match="fixed_polic"):
+    _plan(fixed_policies=("catalytic_triad",))

--- a/tests/host/test_fixed_arms.py
+++ b/tests/host/test_fixed_arms.py
@@ -269,3 +269,75 @@ def test_an_unfixed_row_says_so_rather_than_staying_silent() -> None:
   assert "fixed_mask" in arrays, "an unfixed row must still SAY it fixed nothing"
   assert arrays["fixed_mask"].shape == (_L,)
   assert attrs["n_fixed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The inline declaration: no .npy required to hold three residues
+# ---------------------------------------------------------------------------
+
+
+def test_inline_declaration_needs_no_file_and_yields_BOTH_mask_and_tokens() -> None:
+  """`catalytic_triad=H38|D73|C143` -- the common case, with no file to materialise.
+
+  The letters are not decoration. Freezing a position and choosing its identity are ONE
+  decision: a mask without tokens locks every frozen position to token 0 (Alanine), which is
+  why `_prepare_fixed_controls` refuses that pair outright. The declaration supplies both, so
+  nothing has to infer the identities -- no structure parsed at plan time, no alphabet to get
+  wrong.
+  """
+  from aminx.utils.aa_convert import MPNN_ALPHABET
+
+  rows = _plan(fixed_arms={"catalytic_triad": "H38|D73|C143"})
+  spec = rows[0]["sampling_spec"]
+
+  assert sorted(np.nonzero(np.asarray(spec["fixed_mask"]))[0].tolist()) == list(_TRIAD)
+
+  tokens = np.asarray(spec["fixed_tokens"])
+  held = [MPNN_ALPHABET[int(tokens[p])] for p in _TRIAD]
+  assert held == ["H", "D", "C"], (
+    f"The declared identities did not survive: got {held}, expected His/Asp/Cys. The letters "
+    f"ARE the fixed_tokens; if they do not arrive, every frozen position falls back to token "
+    f"0 -- Alanine -- and a 'fixed catalytic triad' comes back as a dead enzyme."
+  )
+
+
+def test_the_declaration_makes_a_wrong_triad_VISIBLE() -> None:
+  """The property a bare position list cannot have.
+
+  `CATALYTIC_PDB_IDS = [135, 181, 183]` shipped in a consumer for weeks as "the catalytic
+  triad". Those map to canonical [127, 173, 175], which hold **Ser/Ser/Pro** -- not a
+  catalytic triad, not catalytic anything. A bare position list is unfalsifiable on sight:
+  [127,173,175] looks exactly as plausible as [38,73,143].
+
+  Written as a declaration it announces itself -- S127|S173|P175 is visibly not a triad -- and
+  the identities travel into the row where a worker holding the structure can check the claim
+  against the actual residues. This test pins that the letters survive, which is what makes
+  the check possible at all.
+  """
+  from aminx.utils.aa_convert import MPNN_ALPHABET
+
+  rows = _plan(fixed_arms={"looks_plausible": "S127|S173|P175"})
+  tokens = np.asarray(rows[0]["sampling_spec"]["fixed_tokens"])
+
+  assert [MPNN_ALPHABET[int(tokens[p])] for p in (127, 173, 175)] == ["S", "S", "P"]
+
+
+def test_a_position_without_an_identity_is_refused() -> None:
+  """`38|73|143` states where but not what -- and those are one decision, not two."""
+  with pytest.raises(ValueError, match="RESIDUE"):
+    _plan(fixed_arms={"triad": "38|73|143"})
+
+
+def test_a_nonsense_residue_letter_is_refused() -> None:
+  with pytest.raises(ValueError, match="not an amino acid"):
+    _plan(fixed_arms={"triad": "Z38"})
+
+
+def test_an_out_of_range_position_names_the_numbering_convention() -> None:
+  """Off-by-8 is the live error here: author numbering vs canonical index.
+
+  TEV's triad is His46/Asp81/Cys151 in author numbering and [38,73,143] canonical. A caller
+  reaching for `H46` should be told which frame this is, not just "out of range".
+  """
+  with pytest.raises(ValueError, match=r"(?i)canonical"):
+    _plan(fixed_arms={"triad": "H9999"})

--- a/tests/host/test_fixed_tokens_guard.py
+++ b/tests/host/test_fixed_tokens_guard.py
@@ -1,0 +1,159 @@
+"""The Alanine guard: freezing a position without choosing its identity must raise.
+
+`fixed_mask` selects WHICH positions are frozen; `fixed_tokens` says TO WHAT. Setting the first
+without the second used to silently lock every frozen position to token 0 -- Alanine -- because
+decode does `final_token = where(is_group_fixed, fixed_tokens, sampled)`
+(decode/autoregressive.py:340-346) and `fixed_tokens` defaulted to zeros. Range validation never
+caught it: token 0 is a legal amino acid, not a sentinel, and the check sat inside
+`if fixed_tokens is not None`, so it could not fire for the default that needed catching.
+
+Consequence had it shipped: a caller "fixing the catalytic triad" gets Ala/Ala/Ala -- a dead
+enzyme -- with valid-shaped output and no error.
+
+task_id: 260715_aminx-campaign-control-knob-audit
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from aminx.host._sampling_helper import _prepare_fixed_controls, resolve_native_tokens
+from aminx.run.specs import SamplingSpecification
+from aminx.utils.data_structures import Protein
+
+_SEQ_LEN = 8
+_TRIAD = (2, 4, 6)
+
+
+def _protein(batch_size: int = 1, aatype: np.ndarray | None = None) -> Protein:
+  if aatype is None:
+    aatype = np.zeros((batch_size, _SEQ_LEN), dtype=np.int32)
+  return Protein(
+    coordinates=jnp.zeros((batch_size, _SEQ_LEN, 4, 3), dtype=jnp.float32),
+    aatype=jnp.asarray(aatype),
+    atom_mask=jnp.ones((batch_size, _SEQ_LEN, 37), dtype=jnp.float32),
+    residue_index=jnp.arange(_SEQ_LEN, dtype=jnp.int32)[None, :].repeat(batch_size, axis=0),
+    chain_index=jnp.zeros((batch_size, _SEQ_LEN), dtype=jnp.int32),
+    mask=jnp.ones((batch_size, _SEQ_LEN), dtype=jnp.float32),
+    mapping=None,
+  )
+
+
+def _triad_mask() -> np.ndarray:
+  mask = np.zeros(_SEQ_LEN, dtype=np.float32)
+  mask[list(_TRIAD)] = 1.0
+  return mask
+
+
+def _spec(**kw: object) -> SamplingSpecification:
+  return SamplingSpecification(inputs=["x.pdb"], **kw)
+
+
+class TestGuardFires:
+  """The guard must reject the dangerous input. Verified by constructing it deliberately."""
+
+  def test_fixed_mask_without_fixed_tokens_raises(self) -> None:
+    spec = _spec(fixed_mask=_triad_mask())
+    with pytest.raises(ValueError, match="fixed_tokens is None") as exc:
+      _prepare_fixed_controls(spec, batched_ensemble=_protein())
+    # The message must be actionable, not merely correct: it has to name the destructive
+    # default AND both escape routes, or the next caller re-derives this from scratch.
+    text = str(exc.value)
+    assert "Alanine" in text or "'A'" in text
+    assert "fixed_tokens explicitly" in text
+    assert "resolve_native_tokens" in text
+
+  def test_fixed_positions_without_fixed_tokens_raises(self) -> None:
+    """fixed_positions is a mask alias, so it must arm the same guard."""
+    spec = _spec(fixed_positions=_triad_mask())
+    with pytest.raises(ValueError, match="fixed_tokens is None"):
+      _prepare_fixed_controls(spec, batched_ensemble=_protein())
+
+  def test_guard_does_not_fire_when_nothing_is_frozen(self) -> None:
+    """An all-zero mask freezes nothing; there is no identity to choose."""
+    spec = _spec(fixed_mask=np.zeros(_SEQ_LEN, dtype=np.float32))
+    fm, ft = _prepare_fixed_controls(spec, batched_ensemble=_protein())
+    assert not bool(jnp.any(fm))
+    assert not bool(jnp.any(ft))
+
+
+class TestUniformOverride:
+  """The common intent: freeze the triad at the SAME identity in every state."""
+
+  def test_1d_fixed_tokens_locks_one_identity_across_all_states(self) -> None:
+    tokens = np.zeros(_SEQ_LEN, dtype=np.int32)
+    tokens[2], tokens[4], tokens[6] = 6, 2, 1  # H, D, C in MPNN_ALPHABET
+
+    spec = _spec(fixed_mask=_triad_mask(), fixed_tokens=tokens)
+    fm, ft = _prepare_fixed_controls(spec, batched_ensemble=_protein(batch_size=4))
+
+    assert fm.shape == (4, _SEQ_LEN)
+    for state in range(4):
+      assert [int(ft[state, p]) for p in _TRIAD] == [6, 2, 1], (
+        "a 1-D fixed_tokens must broadcast the same identity to every state"
+      )
+      assert [float(fm[state, p]) for p in _TRIAD] == [1.0, 1.0, 1.0]
+
+  def test_the_bug_this_guard_prevents(self) -> None:
+    """Regression: the frozen positions must NOT come back as Alanine."""
+    tokens = np.zeros(_SEQ_LEN, dtype=np.int32)
+    tokens[2], tokens[4], tokens[6] = 6, 2, 1
+
+    spec = _spec(fixed_mask=_triad_mask(), fixed_tokens=tokens)
+    _fm, ft = _prepare_fixed_controls(spec, batched_ensemble=_protein())
+
+    assert [int(ft[0, p]) for p in _TRIAD] != [0, 0, 0], "frozen triad decayed to Ala/Ala/Ala"
+
+
+class TestNativeOverride:
+  """resolve_native_tokens: freeze each position at whatever is already there."""
+
+  def test_resolves_native_and_satisfies_the_guard(self) -> None:
+    aatype = np.array([[0, 5, 6, 5, 2, 5, 1, 5]], dtype=np.int32)
+    ensemble = _protein(aatype=aatype)
+
+    tokens = resolve_native_tokens(ensemble, _triad_mask())
+    spec = _spec(fixed_mask=_triad_mask(), fixed_tokens=tokens)
+    _fm, ft = _prepare_fixed_controls(spec, batched_ensemble=ensemble)
+
+    assert [int(ft[0, p]) for p in _TRIAD] == [6, 2, 1]
+
+  def test_divergent_natives_raise_naming_the_positions(self) -> None:
+    """The C151A case: states disagree at a frozen position, so 'native' is undefined.
+
+    The design is ONE sequence. Silently picking a state is how a dead enzyme ships.
+    """
+    aatype = np.array(
+      [
+        [0, 5, 6, 5, 2, 5, 1, 5],  # position 6 -> C
+        [0, 5, 6, 5, 2, 5, 0, 5],  # position 6 -> A  (the C151A mutant)
+      ],
+      dtype=np.int32,
+    )
+    with pytest.raises(ValueError, match="structures disagree") as exc:
+      resolve_native_tokens(_protein(batch_size=2, aatype=aatype), _triad_mask())
+
+    text = str(exc.value)
+    assert "position 6" in text, "the divergent position must be named, not just counted"
+    assert "fixed_tokens explicitly" in text
+    assert "allow_heterogeneous" in text
+
+  def test_divergence_accepted_only_when_asked_for(self) -> None:
+    aatype = np.array(
+      [
+        [0, 5, 6, 5, 2, 5, 1, 5],
+        [0, 5, 6, 5, 2, 5, 0, 5],
+      ],
+      dtype=np.int32,
+    )
+    tokens = resolve_native_tokens(
+      _protein(batch_size=2, aatype=aatype), _triad_mask(), allow_heterogeneous=True,
+    )
+    assert int(tokens[0, 6]) == 1, "structure 0's residue is taken, deliberately"
+
+  def test_agreeing_natives_need_no_override(self) -> None:
+    aatype = np.array([[0, 5, 6, 5, 2, 5, 1, 5]] * 3, dtype=np.int32)
+    tokens = resolve_native_tokens(_protein(batch_size=3, aatype=aatype), _triad_mask())
+    assert [int(tokens[0, p]) for p in _TRIAD] == [6, 2, 1]

--- a/tests/host/test_fixed_tokens_guard.py
+++ b/tests/host/test_fixed_tokens_guard.py
@@ -21,10 +21,30 @@ import pytest
 
 from aminx.host._sampling_helper import _prepare_fixed_controls, resolve_native_tokens
 from aminx.run.specs import SamplingSpecification
+from aminx.utils.aa_convert import AF_ALPHABET, MPNN_ALPHABET
 from aminx.utils.data_structures import Protein
 
 _SEQ_LEN = 8
 _TRIAD = (2, 4, 6)
+
+# Fixtures are **AF**, because that is what `aatype` actually is. This is not a detail: the
+# previous fixtures were written in MPNN -- `[0, 5, 6, 5, 2, 5, 1, 5]` with a comment reading
+# "position 6 -> C", which is true in MPNN (index 1 = Cys) and false in AF (index 1 = Arg).
+# The author assumed aatype was MPNN, encoded that assumption into the fixture, and the test
+# then agreed with them. A synthetic fixture can only ever confirm its author's belief about
+# the alphabet, which is why the alphabet-sensitive assertions now live in
+# tests/utils/test_alphabet_boundary.py against a real parse. These fixtures stay synthetic
+# because what they test -- whether the guard raises -- is alphabet-agnostic; they just have
+# to stop lying about what they contain.
+def _af(*residues: str) -> np.ndarray:
+  """Build an AF-encoded aatype row from residue letters, so the fixture reads as biology."""
+  return np.array([AF_ALPHABET.index(r) for r in residues], dtype=np.int32)
+
+
+# TEV's catalytic triad at _TRIAD, Gln elsewhere as filler.
+_AF_HDC = _af("A", "Q", "H", "Q", "D", "Q", "C", "Q")[None, :]
+# The C151A mutant: identical except the triad Cys is Ala -- the real 1LVB case.
+_AF_HDA = _af("A", "Q", "H", "Q", "D", "Q", "A", "Q")[None, :]
 
 
 def _protein(batch_size: int = 1, aatype: np.ndarray | None = None) -> Protein:
@@ -111,13 +131,16 @@ class TestNativeOverride:
   """resolve_native_tokens: freeze each position at whatever is already there."""
 
   def test_resolves_native_and_satisfies_the_guard(self) -> None:
-    aatype = np.array([[0, 5, 6, 5, 2, 5, 1, 5]], dtype=np.int32)
-    ensemble = _protein(aatype=aatype)
+    ensemble = _protein(aatype=_AF_HDC)
 
     tokens = resolve_native_tokens(ensemble, _triad_mask())
     spec = _spec(fixed_mask=_triad_mask(), fixed_tokens=tokens)
     _fm, ft = _prepare_fixed_controls(spec, batched_ensemble=ensemble)
 
+    # AF in, MPNN out -- the RESIDUES are preserved, the encoding changes. Asserting the
+    # residues rather than the raw ints is the whole point: `tokens == aatype` was the old
+    # assertion, and it can only hold in one alphabet while naming neither.
+    assert [MPNN_ALPHABET[int(ft[0, p])] for p in _TRIAD] == ["H", "D", "C"]
     assert [int(ft[0, p]) for p in _TRIAD] == [6, 2, 1]
 
   def test_divergent_natives_raise_naming_the_positions(self) -> None:
@@ -127,8 +150,8 @@ class TestNativeOverride:
     """
     aatype = np.array(
       [
-        [0, 5, 6, 5, 2, 5, 1, 5],  # position 6 -> C
-        [0, 5, 6, 5, 2, 5, 0, 5],  # position 6 -> A  (the C151A mutant)
+        *_AF_HDC,  # position 6 -> C
+        *_AF_HDA,  # position 6 -> A  (the C151A mutant)
       ],
       dtype=np.int32,
     )
@@ -141,19 +164,15 @@ class TestNativeOverride:
     assert "allow_heterogeneous" in text
 
   def test_divergence_accepted_only_when_asked_for(self) -> None:
-    aatype = np.array(
-      [
-        [0, 5, 6, 5, 2, 5, 1, 5],
-        [0, 5, 6, 5, 2, 5, 0, 5],
-      ],
-      dtype=np.int32,
-    )
+    aatype = np.concatenate([_AF_HDC, _AF_HDA], axis=0)
     tokens = resolve_native_tokens(
       _protein(batch_size=2, aatype=aatype), _triad_mask(), allow_heterogeneous=True,
     )
-    assert int(tokens[0, 6]) == 1, "structure 0's residue is taken, deliberately"
+    assert MPNN_ALPHABET[int(tokens[0, 6])] == "C", (
+      "structure 0's residue is taken, deliberately -- and it is Cys, not the mutant's Ala"
+    )
 
   def test_agreeing_natives_need_no_override(self) -> None:
-    aatype = np.array([[0, 5, 6, 5, 2, 5, 1, 5]] * 3, dtype=np.int32)
+    aatype = np.repeat(_AF_HDC, 3, axis=0)
     tokens = resolve_native_tokens(_protein(batch_size=3, aatype=aatype), _triad_mask())
-    assert [int(tokens[0, p]) for p in _TRIAD] == [6, 2, 1]
+    assert [MPNN_ALPHABET[int(tokens[0, p])] for p in _TRIAD] == ["H", "D", "C"]

--- a/tests/host/test_inference_plan.py
+++ b/tests/host/test_inference_plan.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import inspect
 import pytest
 
+from aminx.run.spec import build_run_spec
+
 
 # ---------------------------------------------------------------------------
 # 1. Import contract
@@ -74,6 +76,7 @@ def test_inference_plan_has_stage_set_attribute():
         state_weights = None
         temperature = [1.0]
 
+    DummySpec.run_spec = build_run_spec(DummySpec)
     plan = make_inference_plan(DummyModel(), DummySpec())
     assert hasattr(plan, "stage_set"), "InferencePlan instance must have a stage_set attribute"
 
@@ -122,6 +125,7 @@ def test_make_inference_plan_returns_inference_plan():
         state_weights = None
         temperature = [1.0]
 
+    DummySpec.run_spec = build_run_spec(DummySpec)
     plan = make_inference_plan(DummyModel(), DummySpec())
     assert isinstance(plan, InferencePlan), (
         f"make_inference_plan must return InferencePlan, got {type(plan)}"
@@ -145,6 +149,7 @@ def test_make_inference_plan_with_geometric_mean():
         state_weights = None
         temperature = [1.0]
 
+    GeoSpec.run_spec = build_run_spec(GeoSpec)
     plan = make_inference_plan(DummyModel(), GeoSpec())
     assert isinstance(plan.stage_set.logit_transform, GeometricMeanLogits)
 
@@ -173,6 +178,7 @@ def test_make_inference_plan_straight_through_uses_ste_decode():
         temperature = [1.0]
         average_node_features = False
 
+    STESpec.run_spec = build_run_spec(STESpec)
     model = DummyModel(decoder=object(), w_s_embed=type('obj', (object,), {'weight': None})())
     plan = make_inference_plan(model, STESpec())
     assert isinstance(plan.decode_fn, STEDecode), (
@@ -199,6 +205,7 @@ def test_make_inference_plan_temperature_uses_conditional_mode():
         temperature = [1.0]
         average_node_features = False
 
+    TempSpec.run_spec = build_run_spec(TempSpec)
     plan = make_inference_plan(DummyModel(), TempSpec())
     assert isinstance(plan.decode_fn, ConditionalDecode), (
         f"temperature sampling_strategy should use ConditionalDecode, "

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import re
 from dataclasses import fields
 from pathlib import Path
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
@@ -34,7 +35,8 @@ import pytest
 from aminx.host.campaign import plan_campaign_manifest
 from aminx.run.specs import SamplingSpecification, pop_deprecated_spec_kwargs
 from tests.host.knob_observations import (
-  KNOWN_BROKEN_AT_A17,
+  KNOWN_BROKEN_TIER_A,
+  KNOWN_BROKEN_TIER_B,
   OBSERVATIONS,
   Bundle,
   Internal,
@@ -131,9 +133,20 @@ def _tier_a_fields() -> list[str]:
   )
 
 
-def _maybe_xfail(field: str) -> None:
-  if field in KNOWN_BROKEN_AT_A17:
-    pytest.xfail(KNOWN_BROKEN_AT_A17[field])
+def _maybe_xfail(request: pytest.FixtureRequest, field: str, known_broken: Mapping[str, str]) -> None:
+  """Apply a STRICT xfail marker so a fix XPASSes into a red build.
+
+  This used to call `pytest.xfail(reason)` -- which is IMPERATIVE: it aborts the test body
+  immediately and unconditionally marks xfail. The body never ran, so it could never XPASS, so
+  the "a real fix forces the marker's removal" property I relied on all along **did not exist**.
+  Proven when S1a fixed all 12 knobs and the suite still reported 12 xfailed; only `--runxfail`
+  revealed they had started passing.
+
+  A check that cannot fail and a check that cannot pass are the same bug wearing different hats.
+  `request.node.add_marker` runs the body and detects XPASS, which is what strict xfail is for.
+  """
+  if field in known_broken:
+    request.node.add_marker(pytest.mark.xfail(strict=True, reason=known_broken[field]))
 
 
 class TestDeclarationCompleteness:
@@ -207,8 +220,8 @@ class TestDeclarationCompleteness:
     )
 
   def test_known_broken_entries_are_declared(self) -> None:
-    undeclared = set(KNOWN_BROKEN_AT_A17) - set(OBSERVATIONS)
-    assert not undeclared, f"KNOWN_BROKEN_AT_A17 names not in OBSERVATIONS: {sorted(undeclared)}"
+    undeclared = (set(KNOWN_BROKEN_TIER_A) | set(KNOWN_BROKEN_TIER_B)) - set(OBSERVATIONS)
+    assert not undeclared, f"known-broken names not in OBSERVATIONS: {sorted(undeclared)}"
 
 
 class TestTierAManifestSurvival:
@@ -218,8 +231,10 @@ class TestTierAManifestSurvival:
   """
 
   @pytest.mark.parametrize("field", _tier_a_fields())
-  def test_value_survives_the_real_round_trip(self, field: str) -> None:
-    _maybe_xfail(field)
+  def test_value_survives_the_real_round_trip(
+    self, field: str, request: pytest.FixtureRequest,
+  ) -> None:
+    _maybe_xfail(request, field, KNOWN_BROKEN_TIER_A)
     value_a, value_b = DIFFERENTIAL_PAIRS[field]
 
     got_a = _round_trip(field, value_a)
@@ -312,8 +327,9 @@ class TestTierBModelBoundary:
   @pytest.mark.parametrize("field", sorted(FORWARDING_KNOBS))
   def test_value_reaches_load_model(
     self, field: str, minimal_model: Any, monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
   ) -> None:
-    _maybe_xfail(field)
+    _maybe_xfail(request, field, KNOWN_BROKEN_TIER_B)
     kwarg = self.FORWARDING_KNOBS[field]
     captured: list[dict[str, Any]] = []
 
@@ -346,15 +362,40 @@ class TestTierBModelBoundary:
 
 
 class TestNonSerializableKnobsRejected:
-  """Callables must not silently vanish into the manifest."""
+  """Callables must not silently vanish into the manifest.
+
+  UPDATED for the field-driven write. Under the hand-written literal these fields were simply
+  absent, so the test asserted absence. The dump is exhaustive over `fields()`, so a None-valued
+  non-serializable field now appears AS None -- which round-trips correctly and carries no lie.
+
+  The property that actually matters was never "is it absent"; it is **"can it silently carry a
+  wrong value"**. So: None is fine, and a real value must RAISE rather than be dropped. That
+  distinction is the whole audit.
+  """
 
   @pytest.mark.parametrize(
     "field",
     sorted(n for n, v in OBSERVATIONS.items() if isinstance(v, (NonSerializable, Internal))),
   )
-  def test_not_carried_by_the_manifest(self, field: str) -> None:
+  def test_never_carries_a_value(self, field: str) -> None:
     payload = _plan_one_row()
-    assert field not in payload, (
-      f"{field!r} is declared non-serializable/internal but appears in the manifest literal. "
-      "Either it is now serializable (update the declaration) or the literal is wrong."
+    assert payload.get(field) is None, (
+      f"{field!r} is declared non-serializable/internal but the manifest carries "
+      f"{payload.get(field)!r}. A non-serializable field may appear as None (harmless, "
+      f"round-trips); carrying a VALUE means it is serializable after all -- update the "
+      f"declaration -- or the payload is lying."
     )
+
+  def test_setting_a_non_serializable_field_raises_rather_than_drops(self) -> None:
+    """The behavior change that is the point: silent drop -> loud error.
+
+    Under the literal, setting carry_specs on a campaign base_spec was silently ignored. It now
+    raises. No live caller sets it (cli.py's campaign sites set only inputs/return_logits/
+    checkpoint_id/chain_id/ligand_context_path), so this breaks nobody and tells the truth.
+    """
+    from aminx.run.spec_json import SpecJSONEncodeError
+    from xtrax.tiling import CarrySpec
+
+    spec = CarrySpec(axis_name="n_samples", init={"x": 0.0}, transition=lambda c, x: (c, x))
+    with pytest.raises(SpecJSONEncodeError, match="CarrySpec"):
+      _plan_one_row(carry_specs=[spec])

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -65,7 +65,9 @@ def _plan_one_row(**spec_kwargs: Any) -> dict[str, Any]:
     output_root="/tmp/knob-differential",
     designs_per_library_type=1,
     samples_chunk_size=1,
-    fixed_policies=("catalytic_triad",),
+    # No arms: this harness probes whether a knob survives plan -> manifest -> spec, which
+    # is orthogonal to fixing residues. Arms are covered in tests/host/test_fixed_arms.py.
+    fixed_arms=None,
   )
   return dict(rows[0]["sampling_spec"])
 

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -304,6 +304,98 @@ class TestInertKnobsStayInert:
     )
 
 
+class TestArrayKnobFidelity:
+  """Array knobs must reach the worker as arrays, not as the JSON lists they travel as.
+
+  These fields were DROPPED entirely by the old hand-written literal, so no campaign worker had
+  ever received them. The field-driven write is the first time they arrive at all -- and they
+  arrive as plain lists, because the worker's constructor deliberately bypasses spec_json's
+  decoder (to keep strict unknown-key rejection).
+
+  I originally reported this round-trip as "87/88 fields survive". That number came from a
+  comparison containing `if not hasattr(a, "shape") else True` -- it auto-passed every array
+  field, i.e. exactly the ones that change. An independent pass caught it. These tests exist so
+  the claim is checked rather than asserted.
+  """
+
+  # ar_mask is deliberately absent: it is a DEAD spec field -- no consumer anywhere reads it
+  # (build_inference_bundle derives its own from mode/schedule), per this table's own verdict.
+  # Asserting fidelity on a value nothing consumes would be theatre.
+  ARRAY_KNOBS = ("fixed_mask", "fixed_tokens", "bias", "state_weights", "tie_group_map",
+                 "structure_mapping", "state_position_map")
+
+  def _worker_spec(self, **spec_kwargs: Any) -> SamplingSpecification:
+    """Reconstruct via the REAL worker path, including its coercion step."""
+    from aminx.run.spec_json import _coerce_field_value
+
+    payload = dict(_plan_one_row(**spec_kwargs))
+    pop_deprecated_spec_kwargs(payload)
+    coerced = {k: _coerce_field_value(SamplingSpecification, k, v) for k, v in payload.items()}
+    return SamplingSpecification(**coerced)
+
+  @pytest.mark.parametrize("field", ARRAY_KNOBS)
+  def test_array_knob_arrives_as_an_array(self, field: str) -> None:
+    value_a, value_b = DIFFERENTIAL_PAIRS[field]
+    spec = self._worker_spec(**{field: value_b})
+    got = getattr(spec, field)
+
+    assert hasattr(got, "shape"), (
+      f"{field!r} reached the worker as {type(got).__name__}, not an array. It travels as a "
+      f"JSON list and nothing restored the type, so any consumer doing numpy-style indexing "
+      f"(x[:, None], x.shape, take_along_axis) breaks or misbehaves on it."
+    )
+    assert np.array_equal(np.asarray(got), np.asarray(value_b)), (
+      f"{field!r} arrived as an array but with the wrong value"
+    )
+
+  def test_temperature_arrives_as_a_tuple(self) -> None:
+    """temperature is Sequence[float]; __post_init__ coerces a float but never a list."""
+    spec = self._worker_spec(temperature=0.9)
+    assert isinstance(spec.temperature, tuple), (
+      f"temperature reached the worker as {type(spec.temperature).__name__}, not tuple"
+    )
+
+  def test_tie_group_map_survives_kernel_dispatchs_raw_use(self) -> None:
+    """The one consumer that does NOT wrap defensively -- found by an independent audit pass.
+
+    `kernel_dispatch.py:143-147` does `jnp.atleast_2d(spec.tie_group_map)` and
+    `spec.tie_group_map.shape[0]` on the RAW value. `jnp.atleast_2d` refuses a plain list
+    outright (stricter than numpy's), so a single-structure campaign row setting tie_group_map
+    hard-crashes without coercion. The PoE path (multistate_poe.py:310) wraps correctly; this
+    one does not.
+
+    Note the behavior history: before the field-driven write, such a row ran SILENTLY WITHOUT
+    tying (the field was dropped). After it, the row crashed. After coercion, it works. Tier A
+    could never have caught this -- it only checks the reconstructed spec's value, never drives
+    it through kernel_dispatch.
+    """
+    import jax.numpy as jnp
+
+    spec = self._worker_spec(tie_group_map=np.array([0, 0, 1, 1], dtype=np.int32))
+    # The exact expression from kernel_dispatch.py:143-147.
+    result = jnp.broadcast_to(
+      jnp.atleast_2d(spec.tie_group_map), (2, spec.tie_group_map.shape[0]),
+    )
+    assert result.shape == (2, 4)
+
+  def test_coercion_does_not_cost_strict_unknown_key_rejection(self) -> None:
+    """The reason the worker keeps the plain constructor rather than spec_json's decoder.
+
+    Coercion is a value transform, so an unknown key still reaches the constructor and raises.
+    If this ever regresses, the manifest silently accepts typo'd keys -- trading one
+    silent-failure class for another, which would be an absurd outcome for this audit.
+    """
+    from aminx.run.spec_json import _coerce_field_value
+
+    payload = dict(_plan_one_row())
+    pop_deprecated_spec_kwargs(payload)
+    payload["not_a_real_field"] = 123
+    coerced = {k: _coerce_field_value(SamplingSpecification, k, v) for k, v in payload.items()}
+
+    with pytest.raises(TypeError, match="not_a_real_field"):
+      SamplingSpecification(**coerced)
+
+
 class TestTierBModelBoundary:
   """Does the value reach the MODEL, not just the manifest?
 

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -1,0 +1,264 @@
+"""Differential harness: does a control knob a caller sets actually reach the model?
+
+Ten times an aminx control knob has been declared on the config surface, appeared to work, and
+silently never reached the model. Every one was found incidentally; none by a systematic sweep.
+Existing conditioning tests miss them because they build `Protein`/bundle objects directly and
+bypass the CLI -> manifest -> spec -> runner layer where all the bugs actually live.
+
+This converts "is this knob wired?" from a code-reading judgment (which has failed every time)
+into an executable assertion, driven through the REAL path:
+
+    plan_campaign_manifest -> row["sampling_spec"] JSON -> SamplingSpecification(**payload)
+                           -> [Tier B] real runner -> spy at load_model / build_inference_bundle
+
+Tier A needs no model and no structure and runs in milliseconds; it covers the manifest-drop
+class, which is 6 of the 10 known occurrences. Tier B spies at the model boundary for the hops
+Tier A cannot see.
+
+Expected behavior per field lives in `knob_observations.py` -- see that module for why declared
+intent is required rather than a bare value-diff.
+
+task_id: 260715_aminx-campaign-control-knob-audit
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any
+
+import numpy as np
+import pytest
+
+from aminx.host.campaign import plan_campaign_manifest
+from aminx.run.specs import SamplingSpecification, pop_deprecated_spec_kwargs
+from tests.host.knob_observations import (
+  KNOWN_BROKEN_AT_A17,
+  OBSERVATIONS,
+  Bundle,
+  Internal,
+  LoadModel,
+  NonSerializable,
+  NotApplicable,
+  Overridden,
+  SpecOnly,
+)
+
+pytestmark = pytest.mark.knob_differential
+
+_LIGAND_CKPT = "ligandmpnn_v_32_020_25"
+
+
+def _plan_one_row(**spec_kwargs: Any) -> dict[str, Any]:
+  """Drive the REAL planner and return the row's serialized sampling_spec."""
+  base = SamplingSpecification(
+    inputs=["ref.pdb"],
+    checkpoint_id=_LIGAND_CKPT,
+    **spec_kwargs,
+  )
+  rows = plan_campaign_manifest(
+    base_spec=base,
+    campaign_id="knob-differential",
+    output_root="/tmp/knob-differential",
+    designs_per_library_type=1,
+    samples_chunk_size=1,
+    fixed_policies=("catalytic_triad",),
+  )
+  return dict(rows[0]["sampling_spec"])
+
+
+def _reconstruct(payload: dict[str, Any]) -> SamplingSpecification:
+  """Reconstruct exactly as the worker does (campaign.py:853-856).
+
+  Deliberately mirrors the real worker rather than using spec_json: the harness must not
+  diverge from the path under test, or it stops testing anything real.
+  """
+  worker_payload = dict(payload)
+  pop_deprecated_spec_kwargs(worker_payload)
+  return SamplingSpecification(**worker_payload)
+
+
+def _round_trip(field: str, value: Any) -> Any:
+  """Set `field` on base_spec, drive the real path, return the reconstructed value."""
+  spec = _reconstruct(_plan_one_row(**{field: value}))
+  return getattr(spec, field)
+
+
+def _equal(a: Any, b: Any) -> bool:
+  if a is None or b is None:
+    return a is b
+  try:
+    return bool(np.array_equal(np.asarray(a), np.asarray(b)))
+  except (TypeError, ValueError):
+    return a == b
+
+
+# Differential pairs: (field, value_a, value_b). Values must be legal on their own so a
+# failure means "the knob was dropped", never "the spec rejected my input".
+DIFFERENTIAL_PAIRS: dict[str, tuple[Any, Any]] = {
+  "fixed_mask": (np.zeros(4, dtype=np.float32), np.array([1, 0, 1, 0], dtype=np.float32)),
+  "fixed_positions": (np.zeros(4, dtype=np.float32), np.array([0, 1, 0, 1], dtype=np.float32)),
+  "fixed_tokens": (np.zeros(4, dtype=np.int32), np.array([3, 3, 3, 3], dtype=np.int32)),
+  "state_position_map": (np.zeros((1, 4), dtype=np.int32), np.arange(4, dtype=np.int32)[None, :]),
+  "state_weights": (np.array([1.0], dtype=np.float32), np.array([0.5], dtype=np.float32)),
+  "bias": (np.zeros((4, 21), dtype=np.float32), np.ones((4, 21), dtype=np.float32)),
+  "tie_group_map": (np.zeros(4, dtype=np.int32), np.array([0, 0, 1, 1], dtype=np.int32)),
+  "structure_mapping": (np.zeros(4, dtype=np.int32), np.arange(4, dtype=np.int32)),
+  "multi_state_strategy": ("arithmetic_mean", "product"),
+  "ligand_mpnn_use_side_chain_context": (False, True),
+  "sidechain_conditioning": (False, True),
+  "ligand_conditioning": (False, True),
+  "use_electrostatics": (False, True),
+  "use_vdw": (False, True),
+  "temperature": (0.1, 0.9),
+  "backbone_noise": (0.0, 0.25),
+  "batch_size": (2, 8),
+  "model_weights": ("original", "soluble"),
+  "chain_id": ("A", "B"),
+  "model_family": ("ligandmpnn", "proteinmpnn"),
+}
+
+_TIER_A_OBSERVABLE = (Bundle, LoadModel, SpecOnly)
+
+
+def _tier_a_fields() -> list[str]:
+  """Fields whose declared verdict implies the value must survive the manifest."""
+  return sorted(
+    name
+    for name, verdict in OBSERVATIONS.items()
+    if isinstance(verdict, _TIER_A_OBSERVABLE) and name in DIFFERENTIAL_PAIRS
+  )
+
+
+def _maybe_xfail(field: str) -> None:
+  if field in KNOWN_BROKEN_AT_A17:
+    pytest.xfail(KNOWN_BROKEN_AT_A17[field])
+
+
+class TestDeclarationCompleteness:
+  """The drift guard: a new spec field with no declared verdict is a red build.
+
+  This is what makes occurrence #11 structurally impossible. It is the same failure the audit
+  exists to answer for -- `plan_campaign_manifest`'s hand-written literal drifting from an
+  88-field dataclass with nothing enforcing the sync.
+  """
+
+  def test_every_spec_field_has_a_declared_observation(self) -> None:
+    declared = set(OBSERVATIONS)
+    actual = {f.name for f in fields(SamplingSpecification)}
+
+    undeclared = actual - declared
+    assert not undeclared, (
+      f"Spec field(s) with no declared observation: {sorted(undeclared)}. "
+      "Add an entry to tests/host/knob_observations.py declaring how this knob behaves in "
+      "campaign mode and where it is observable. An undeclared field is exactly how the "
+      "previous ten silent-knob bugs reached production."
+    )
+
+    stale = declared - actual
+    assert not stale, f"Declared field(s) that no longer exist on the spec: {sorted(stale)}"
+
+  def test_every_reason_cites_something(self) -> None:
+    """A verdict whose reason asserts a conclusion without evidence is not a verdict."""
+    vague = [
+      name
+      for name, verdict in OBSERVATIONS.items()
+      if len(verdict.reason) < 20
+    ]
+    assert not vague, f"Verdicts needing an evidenced reason: {vague}"
+
+  def test_known_broken_entries_are_declared(self) -> None:
+    undeclared = set(KNOWN_BROKEN_AT_A17) - set(OBSERVATIONS)
+    assert not undeclared, f"KNOWN_BROKEN_AT_A17 names not in OBSERVATIONS: {sorted(undeclared)}"
+
+
+class TestTierAManifestSurvival:
+  """Does a caller's value survive plan -> manifest JSON -> reconstructed spec?
+
+  No model, no structure, milliseconds. This is where 6 of the 10 known occurrences live.
+  """
+
+  @pytest.mark.parametrize("field", _tier_a_fields())
+  def test_value_survives_the_real_round_trip(self, field: str) -> None:
+    _maybe_xfail(field)
+    value_a, value_b = DIFFERENTIAL_PAIRS[field]
+
+    got_a = _round_trip(field, value_a)
+    got_b = _round_trip(field, value_b)
+
+    assert not _equal(got_a, got_b), (
+      f"{field!r} is a SILENT NO-OP: caller set {value_a!r} vs {value_b!r}, but both "
+      f"reconstruct to {got_a!r}. The value never survives the manifest, so the campaign "
+      f"runs with the dataclass default regardless of what the caller asked for. "
+      f"Declared verdict: {OBSERVATIONS[field]}"
+    )
+
+
+class TestOverriddenKnobsAreOverridden:
+  """Campaign deliberately overrides these. Assert the override, not the caller's input.
+
+  Without this, a naive differential reports all four as "not wired" -- false alarms that
+  would discredit the harness immediately.
+  """
+
+  @pytest.mark.parametrize(
+    "field",
+    sorted(n for n, v in OBSERVATIONS.items() if isinstance(v, Overridden)),
+  )
+  def test_campaign_overrides_the_caller(self, field: str) -> None:
+    verdict = OBSERVATIONS[field]
+    assert isinstance(verdict, Overridden)
+
+    payload = _plan_one_row()
+    if field not in payload:
+      pytest.skip(f"{field} is not carried by the manifest literal at all")
+
+    spec = _reconstruct(payload)
+    got = getattr(spec, field)
+
+    if verdict.value is None:
+      return  # per-row planner value; asserted by the planner's own tests
+    assert got == verdict.value, (
+      f"{field!r} should be overridden to {verdict.value!r} by the campaign planner "
+      f"({verdict.reason}), got {got!r}. Either the override changed or the declaration is stale."
+    )
+
+
+class TestInertKnobsStayInert:
+  """NOT_APPLICABLE knobs must remain absent from the manifest.
+
+  If one starts being carried, the declaration is stale and must be re-adjudicated. This is
+  the guard against a fix silently invalidating a triage verdict.
+  """
+
+  @pytest.mark.parametrize(
+    "field",
+    sorted(
+      n for n, v in OBSERVATIONS.items()
+      if isinstance(v, NotApplicable) and n in DIFFERENTIAL_PAIRS
+    ),
+  )
+  def test_declared_inert_knob_is_still_inert(self, field: str) -> None:
+    value_a, value_b = DIFFERENTIAL_PAIRS[field]
+    got_a = _round_trip(field, value_a)
+    got_b = _round_trip(field, value_b)
+
+    assert _equal(got_a, got_b), (
+      f"{field!r} is declared NOT_APPLICABLE in campaign mode "
+      f"({OBSERVATIONS[field].reason}) but its value now SURVIVES the round trip "
+      f"({got_a!r} vs {got_b!r}). The declaration is stale -- re-adjudicate it."
+    )
+
+
+class TestNonSerializableKnobsRejected:
+  """Callables must not silently vanish into the manifest."""
+
+  @pytest.mark.parametrize(
+    "field",
+    sorted(n for n, v in OBSERVATIONS.items() if isinstance(v, (NonSerializable, Internal))),
+  )
+  def test_not_carried_by_the_manifest(self, field: str) -> None:
+    payload = _plan_one_row()
+    assert field not in payload, (
+      f"{field!r} is declared non-serializable/internal but appears in the manifest literal. "
+      "Either it is now serializable (update the declaration) or the literal is wrong."
+    )

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -23,7 +23,9 @@ task_id: 260715_aminx-campaign-control-knob-audit
 
 from __future__ import annotations
 
+import re
 from dataclasses import fields
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -157,14 +159,52 @@ class TestDeclarationCompleteness:
     stale = declared - actual
     assert not stale, f"Declared field(s) that no longer exist on the spec: {sorted(stale)}"
 
-  def test_every_reason_cites_something(self) -> None:
-    """A verdict whose reason asserts a conclusion without evidence is not a verdict."""
-    vague = [
-      name
-      for name, verdict in OBSERVATIONS.items()
-      if len(verdict.reason) < 20
-    ]
-    assert not vague, f"Verdicts needing an evidenced reason: {vague}"
+  @pytest.mark.xfail(
+    strict=True,
+    reason=(
+      "~30 verdicts (mostly host/IO knobs: cache_path, split, max_workers, ...) still cite "
+      "nothing -- they assert 'host-side cache location' rather than pointing at a line. The "
+      "PREDICATE is correct and deliberately not weakened to make this pass; weakening it is "
+      "what let the carry_specs fabrication through in the first place. The TABLE is what owes "
+      "work. Cite them and this XPASSes -> red -> delete this marker. Tracked in sprint S5."
+    ),
+  )
+  def test_every_reason_cites_resolvable_evidence(self) -> None:
+    """A verdict whose reason asserts a conclusion without evidence is not a verdict.
+
+    An earlier version of this test checked `len(verdict.reason) < 20` -- it tested reason
+    LENGTH, not truth. Under it I declared carry_specs/dedup_specs as "streaming/sink
+    bookkeeping (host/streaming.py); never touches the model", which is fabricated (they feed
+    the planner at host/plan.py:79-80). 62 > 20, so it passed. An external review caught it,
+    not this test.
+
+    A predicate cheap to satisfy by writing more prose is not enforcement. This one demands a
+    citation that actually RESOLVES against the source tree, so a reason cannot be satisfied by
+    inventing a plausible-sounding file.
+    """
+    src = Path(__file__).resolve().parents[2] / "src" / "aminx"
+    offenders: list[str] = []
+
+    for name, verdict in OBSERVATIONS.items():
+      # A citation is a source path (foo/bar.py[:123]) or a resolvable symbol reference.
+      paths = re.findall(r"\b([\w/]+\.py)\b", verdict.reason)
+      symbols = re.findall(r"\b(_?[a-z][\w]*(?:_[\w]+)+)\(\)", verdict.reason)
+      if not paths and not symbols:
+        offenders.append(f"{name}: no file.py or symbol() citation in reason")
+        continue
+      for rel in paths:
+        # Reasons cite paths at varying depth -- "host/plan.py", a bare "_sampling_helper.py",
+        # sometimes "aminx/run/specs.py". Resolve by basename anywhere under src/ (or tests/,
+        # for reasons that cite a test as evidence). The point is that the cited file EXISTS,
+        # not that the author wrote its full path.
+        stem = rel.rsplit("/", 1)[-1]
+        if not (any(src.rglob(stem)) or any((src.parents[1] / "tests").rglob(stem))):
+          offenders.append(f"{name}: cites {rel!r}, which resolves to no file under src/")
+
+    assert not offenders, (
+      "Verdict reasons must cite evidence that resolves, not assert a conclusion:\n  "
+      + "\n  ".join(offenders)
+    )
 
   def test_known_broken_entries_are_declared(self) -> None:
     undeclared = set(KNOWN_BROKEN_AT_A17) - set(OBSERVATIONS)

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -386,6 +386,23 @@ class TestNonSerializableKnobsRejected:
       f"declaration -- or the payload is lying."
     )
 
+  def test_a_callable_knob_raises_rather_than_dropping_silently(self) -> None:
+    """Occurrence #13, created by the fix for the first twelve, and caught by an audit agent.
+
+    spec_json drops callables silently (`if callable(val): continue`), so `decoding_order_fn` --
+    a real, supported knob -- still vanished from the manifest after the field-driven write.
+    Worse, spec_partition's own documentation asserted this was impossible. A campaign that
+    silently substitutes the default decoding order produces designs that differ from what was
+    asked for, with no error: precisely the bug class this audit exists to end.
+    """
+    from aminx.host.spec_partition import SpecPartitionError
+
+    def custom_order(*_args: Any, **_kwargs: Any) -> None:
+      return None
+
+    with pytest.raises(SpecPartitionError, match="decoding_order_fn"):
+      _plan_one_row(decoding_order_fn=custom_order)
+
   def test_setting_a_non_serializable_field_raises_rather_than_drops(self) -> None:
     """The behavior change that is the point: silent drop -> loud error.
 

--- a/tests/host/test_knob_differential.py
+++ b/tests/host/test_knob_differential.py
@@ -249,6 +249,62 @@ class TestInertKnobsStayInert:
     )
 
 
+class TestTierBModelBoundary:
+  """Does the value reach the MODEL, not just the manifest?
+
+  Tier A cannot see this hop, and that gap is dangerous rather than merely incomplete: the
+  three knobs below are broken in TWO places -- dropped by the manifest AND never forwarded
+  from prep.py to load_model. Fix only the manifest (4a) and all three XPASS Tier A while
+  remaining broken, so their xfail markers get deleted and three real bugs are certified
+  working. Tier B is what keeps that honest.
+
+  Drives the real path: plan -> manifest JSON -> reconstructed spec -> prep_protein_stream_and_model
+  -> load_model. Spies on load_model rather than loading real weights, so no checkpoint is needed.
+  """
+
+  # spec field -> the load_model kwarg it must arrive as
+  FORWARDING_KNOBS = {
+    "ligand_mpnn_use_side_chain_context": "use_side_chain_context",
+    "use_electrostatics": "use_electrostatics",
+    "use_vdw": "use_vdw",
+  }
+
+  @pytest.mark.parametrize("field", sorted(FORWARDING_KNOBS))
+  def test_value_reaches_load_model(
+    self, field: str, minimal_model: Any, monkeypatch: pytest.MonkeyPatch,
+  ) -> None:
+    _maybe_xfail(field)
+    kwarg = self.FORWARDING_KNOBS[field]
+    captured: list[dict[str, Any]] = []
+
+    def _spy_load_model(**kwargs: Any) -> Any:
+      captured.append(kwargs)
+      return minimal_model
+
+    monkeypatch.setattr("aminx.host.prep.load_model", _spy_load_model)
+
+    from aminx.host.prep import prep_protein_stream_and_model
+
+    def _kwarg_for(value: Any) -> Any:
+      captured.clear()
+      payload = _plan_one_row(**{field: value})
+      payload["inputs"] = ["tests/data/1ubq.pdb"]
+      spec = _reconstruct(payload)
+      prep_protein_stream_and_model(spec)
+      assert captured, "load_model was never called -- the spy is misplaced, not the knob broken"
+      return captured[-1].get(kwarg, "<ABSENT>")
+
+    got_false = _kwarg_for(False)
+    got_true = _kwarg_for(True)
+
+    assert got_false != got_true, (
+      f"{field!r} never reaches the model: caller set False vs True, but load_model received "
+      f"{kwarg}={got_false!r} both times. The model is built identically either way, so the knob "
+      f"is inert at the model boundary even if it survives the manifest. "
+      f"Declared verdict: {OBSERVATIONS[field]}"
+    )
+
+
 class TestNonSerializableKnobsRejected:
   """Callables must not silently vanish into the manifest."""
 

--- a/tests/host/test_packer_integration.py
+++ b/tests/host/test_packer_integration.py
@@ -14,6 +14,7 @@ import jax.numpy as jnp
 import equinox as eqx
 
 from aminx.host.plan import InferencePlan, InferenceComponents, make_inference_plan
+from aminx.run.spec import build_run_spec
 from aminx.types.bundles import (
     InferenceBundle,
     GeometryBundle,
@@ -95,6 +96,7 @@ def test_inference_plan_decode_with_packer_active():
         state_weights = None
         temperature = [1.0]
 
+    DummySpec.run_spec = build_run_spec(DummySpec)
     # Create plan
     plan = make_inference_plan(DummyModel(), DummySpec(), packer=packer_model)
     assert plan.packer is packer_model
@@ -203,8 +205,9 @@ def test_inference_plan_decode_safety_validation():
         state_weights = None
         temperature = [1.0]
 
+    DummySpec.run_spec = build_run_spec(DummySpec)
     plan = make_inference_plan(DummyModel(), DummySpec(), packer=packer_model)
-    
+
     # Create bundle without packer
     geom = GeometryBundle(
         coords=jnp.zeros((1, 5, 4, 3)),

--- a/tests/host/test_sampling_helper.py
+++ b/tests/host/test_sampling_helper.py
@@ -55,7 +55,10 @@ class TestPrepareFixedControlsFixedMask:
 
     # 1D float mask: positions 3, 5, 7 are fixed
     fixed_mask_1d = np.array([0., 0., 0., 1., 0., 1., 0., 1., 0., 0.], dtype=np.float32)
-    spec = SamplingSpecification(inputs=[], fixed_mask=fixed_mask_1d)
+    spec = SamplingSpecification(
+      inputs=[], fixed_mask=fixed_mask_1d,
+      fixed_tokens=np.zeros(seq_len, dtype=np.int32),
+    )
 
     # Call _prepare_fixed_controls
     fixed_mask_out, _ = _prepare_fixed_controls(spec, batched_ensemble=protein)
@@ -84,7 +87,10 @@ class TestPrepareFixedControlsFixedMask:
         ],
         dtype=np.float32,
     )
-    spec = SamplingSpecification(inputs=[], fixed_mask=fixed_mask_2d)
+    spec = SamplingSpecification(
+      inputs=[], fixed_mask=fixed_mask_2d,
+      fixed_tokens=np.zeros(seq_len, dtype=np.int32),
+    )
 
     fixed_mask_out, _ = _prepare_fixed_controls(spec, batched_ensemble=protein)
 
@@ -105,7 +111,7 @@ class TestPrepareFixedControlsFixedMask:
     # fixed_positions: positions 4, 6, 8 are fixed (1D array means broadcast to all batches)
     fixed_positions = np.array([0., 0., 0., 0., 1., 0., 1., 0., 1., 0.], dtype=np.float32)
 
-    spec = SamplingSpecification(inputs=[], fixed_mask=fixed_mask, fixed_positions=fixed_positions)
+    spec = SamplingSpecification(inputs=[], fixed_mask=fixed_mask, fixed_positions=fixed_positions, fixed_tokens=np.zeros(seq_len, dtype=np.int32))
 
     fixed_mask_out, _ = _prepare_fixed_controls(spec, batched_ensemble=protein)
 
@@ -123,7 +129,10 @@ class TestPrepareFixedControlsFixedMask:
     protein = _make_fake_protein(batch_size=batch_size, seq_len=seq_len)
 
     fixed_mask = np.array([0., 0., 1., 0., 1., 0., 0., 0., 0., 0.], dtype=np.float32)
-    spec = SamplingSpecification(inputs=[], fixed_mask=fixed_mask)
+    spec = SamplingSpecification(
+      inputs=[], fixed_mask=fixed_mask,
+      fixed_tokens=np.zeros(seq_len, dtype=np.int32),
+    )
 
     # Apply once
     fixed_mask_out1, _ = _prepare_fixed_controls(spec, batched_ensemble=protein)
@@ -168,7 +177,10 @@ class TestPrepareFixedControlsFixedMask:
 
     # A mask that should be applied exactly once
     fixed_mask = np.array([0., 0., 1., 0., 1., 0., 0., 0., 0., 0.], dtype=np.float32)
-    spec = SamplingSpecification(inputs=[], fixed_mask=fixed_mask)
+    spec = SamplingSpecification(
+      inputs=[], fixed_mask=fixed_mask,
+      fixed_tokens=np.zeros(seq_len, dtype=np.int32),
+    )
 
     fixed_mask_out, _ = _prepare_fixed_controls(spec, batched_ensemble=protein)
 

--- a/tests/inference/test_plan_reuse_compiles_once.py
+++ b/tests/inference/test_plan_reuse_compiles_once.py
@@ -27,6 +27,7 @@ import jax.numpy as jnp
 from aminx.model.mpnn import Aminx
 from aminx.inference.bundle_builder import build_inference_bundle
 from aminx.host.plan import make_inference_plan
+from aminx.run.spec import build_run_spec
 from aminx.types.configs import InferenceConfig
 
 
@@ -52,6 +53,11 @@ class _DummySpec:
     state_weights = None
     temperature = [1.0]
     average_node_features = False
+
+
+# make_inference_plan reads decode-relevant fields from spec.run_spec.sampling (260716, EPIC
+# #1541 P4); build_run_spec() handles any duck spec via getattr(spec, "field", default).
+_DummySpec.run_spec = build_run_spec(_DummySpec)
 
 
 def _make_bundle_and_config(model, L=10, S=1):

--- a/tests/sampling/test_spec_fixed_mask.py
+++ b/tests/sampling/test_spec_fixed_mask.py
@@ -36,9 +36,16 @@ def _base_spec(**kwargs):
 
 
 def test_fixed_mask_no_fixed_positions(fake_batch):
-    """fixed_mask alone (no fixed_positions) must be reflected in the output."""
+    """fixed_mask alone (no fixed_positions) must be reflected in the output.
+
+    fixed_tokens is supplied explicitly (arbitrary values, irrelevant to this test's
+    assertion) because the Alanine guard (026403d) refuses fixed_mask with any nonzero
+    entry when fixed_tokens is None -- freezing a position and choosing its identity are
+    one decision, not two. This test only checks mask reflection, not token identity.
+    """
     mask = np.array([1, 0, 1, 0, 0, 1, 0, 0, 0, 0], dtype=np.float32)
-    spec = _base_spec(fixed_mask=mask)
+    tokens = np.zeros(N, dtype=np.int32)
+    spec = _base_spec(fixed_mask=mask, fixed_tokens=tokens)
     fm, _ft = _prepare_fixed_controls(spec, batched_ensemble=fake_batch)
     result = np.array(fm[0])
     np.testing.assert_array_equal(
@@ -49,12 +56,18 @@ def test_fixed_mask_no_fixed_positions(fake_batch):
 
 
 def test_fixed_mask_union_with_fixed_positions(fake_batch):
-    """fixed_mask and fixed_positions together must union (OR) their masked positions."""
+    """fixed_mask and fixed_positions together must union (OR) their masked positions.
+
+    fixed_tokens is supplied explicitly for the same reason as
+    test_fixed_mask_no_fixed_positions above -- the Alanine guard requires it whenever
+    fixed_mask has a nonzero entry; irrelevant to this test's union-logic assertion.
+    """
     pos_mask = np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32)  # position 0
     fm_mask = np.array([0, 0, 1, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32)   # position 2
     expected = np.array([1, 0, 1, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32)
+    tokens = np.zeros(N, dtype=np.int32)
 
-    spec = _base_spec(fixed_positions=pos_mask, fixed_mask=fm_mask)
+    spec = _base_spec(fixed_positions=pos_mask, fixed_mask=fm_mask, fixed_tokens=tokens)
     fm, _ft = _prepare_fixed_controls(spec, batched_ensemble=fake_batch)
     result = np.array(fm[0])
     np.testing.assert_array_equal(
@@ -77,13 +90,23 @@ def test_fixed_mask_none_unchanged(fake_batch):
 
 
 def test_fixed_mask_does_not_affect_fixed_tokens(fake_batch):
-    """Setting fixed_mask must not alter fixed_tokens output."""
+    """Setting fixed_mask must not alter an explicitly-supplied fixed_tokens value.
+
+    Originally tested the (now-refused) scenario of fixed_mask set with fixed_tokens
+    unset, asserting the silent all-zero-Alanine default -- exactly the behavior the
+    Alanine guard (026403d) exists to refuse ("freezing a position and choosing its
+    identity are one decision, not two"). Modernized to test the same underlying claim
+    (fixed_mask and fixed_tokens are independent fields; setting one doesn't reach into
+    the other) using an explicit, distinctive fixed_tokens value instead of relying on
+    the no-longer-permitted implicit default.
+    """
     mask = np.ones(N, dtype=np.float32)
-    spec = _base_spec(fixed_mask=mask)
+    tokens = np.full(N, 5, dtype=np.int32)
+    spec = _base_spec(fixed_mask=mask, fixed_tokens=tokens)
     _fm, ft = _prepare_fixed_controls(spec, batched_ensemble=fake_batch)
     result = np.array(ft[0])
     np.testing.assert_array_equal(
         result,
-        np.zeros(N, dtype=np.int32),
-        err_msg="fixed_tokens should stay all-zeros when only fixed_mask is set (no fixed_tokens spec)",
+        tokens,
+        err_msg="fixed_tokens should pass through unchanged when fixed_mask is also set",
     )

--- a/tests/scoring/test_averaged_parity.py
+++ b/tests/scoring/test_averaged_parity.py
@@ -427,6 +427,15 @@ class _MinimalScoringSpec:
         backbone_noise=(0.0,),
         random_seed=42,
         return_decoding_orders=False,
+        # Decode-relevant fields make_inference_plan reads via spec.run_spec.sampling.*
+        # (260716, EPIC #1541 P4) -- mirror the class attrs above rather than duplicating
+        # new values, so this fixture can't silently drift from its own declared intent.
+        use_rolling_state=self.use_rolling_state,
+        multi_state_strategy=self.multi_state_strategy,
+        multi_state_temperature=self.multi_state_temperature,
+        state_weights=self.state_weights,
+        sampling_strategy=self.sampling_strategy,
+        decoding_order_fn=None,
       ),
     )
 

--- a/tests/utils/test_alphabet_boundary.py
+++ b/tests/utils/test_alphabet_boundary.py
@@ -165,6 +165,49 @@ def _native_recovery(structure: dict, sequence: jnp.ndarray) -> float:
 
 
 @pytest.mark.alphabet_boundary
+def test_resolve_native_tokens_returns_mpnn() -> None:
+  """``resolve_native_tokens`` must return MPNN, because decode substitutes it as MPNN.
+
+  Real parse, deliberately. ``tests/host/test_fixed_tokens_guard.py`` covers this function
+  well for *raising* behaviour, which is alphabet-agnostic, using synthetic fixtures -- and
+  that is fine. What no test covered was the **alphabet of the return value**, and a
+  synthetic fixture could never have covered it: the fixture author would have written the
+  aatype in whichever alphabet they already believed, and the test would have agreed with
+  them. That is exactly how this bug shipped in 026403d.
+
+  The check is against 1UBQ's real residues: freeze position 0 and the function must report
+  the token for Met, in MPNN. Under the old raw-AF return it reported AF's Met (12), which
+  MPNN reads as Asn.
+  """
+  from aminx.host._sampling_helper import resolve_native_tokens  # noqa: PLC0415
+  from aminx.io.parsing import parse_structure  # noqa: PLC0415
+
+  protein = _first_protein(parse_structure(str(_UBQ)))
+  aatype = np.asarray(protein.aatype)[None, :]  # type: ignore[attr-defined]
+
+  class _Ensemble:
+    pass
+
+  ensemble = _Ensemble()
+  ensemble.aatype = jnp.asarray(aatype)  # type: ignore[attr-defined]
+
+  fixed_mask = np.zeros(aatype.shape[1], dtype=np.float32)
+  fixed_mask[0] = 1.0  # 1UBQ position 0 is Met
+
+  tokens = np.asarray(resolve_native_tokens(ensemble, fixed_mask))  # type: ignore[arg-type]
+
+  assert MPNN_ALPHABET[int(tokens[0, 0])] == "M", (
+    f"resolve_native_tokens returned token {int(tokens[0, 0])}, which is "
+    f"'{MPNN_ALPHABET[int(tokens[0, 0])]}' in MPNN -- but 1UBQ position 0 is Met. The "
+    f"return value feeds fixed_tokens, which decode substitutes directly against "
+    f"MPNN-sampled tokens, so it must be MPNN."
+  )
+  # The whole sequence, not just the frozen position: the function returns a full-length
+  # array and every entry has to be in the same alphabet.
+  assert _decode(tokens[0], MPNN_ALPHABET) == _UBQ_SEQUENCE
+
+
+@pytest.mark.alphabet_boundary
 @pytest.mark.requires_weights
 @pytest.mark.slow
 def test_model_consumes_mpnn_not_af(_ubq_structure: dict) -> None:

--- a/tests/utils/test_alphabet_boundary.py
+++ b/tests/utils/test_alphabet_boundary.py
@@ -137,12 +137,12 @@ def _ubq_structure() -> dict:
   }
 
 
-def _native_recovery(structure: dict, sequence: jnp.ndarray) -> float:
-  """Fraction of positions where the model's argmax equals the supplied sequence.
+def _conditional_logits(structure: dict, sequence: jnp.ndarray) -> jnp.ndarray:
+  """Conditional logits for ``sequence`` against ``structure``, via the real factory.
 
   Uses ``make_conditional_logits_fn`` deliberately: it is the exact factory
-  ``host/runner.py:774`` uses for the ``conditional_logits`` feature, so this measures the
-  real shipped path rather than a reconstruction of it.
+  ``host/runner.py:779`` uses for the ``conditional_logits`` feature, so tests built on this
+  measure the shipped path rather than a reconstruction of it.
   """
   from aminx.io.weights import load_model  # noqa: PLC0415
   from aminx.sampling.conditional_logits import make_conditional_logits_fn  # noqa: PLC0415
@@ -161,6 +161,19 @@ def _native_recovery(structure: dict, sequence: jnp.ndarray) -> float:
   )
   if logits.ndim == 3:  # noqa: PLR2004 -- (1, L, 21) vs (L, 21)
     logits = logits[0]
+  return logits
+
+
+def _native_recovery(structure: dict, sequence: jnp.ndarray) -> float:
+  """Fraction of positions where the model's argmax equals the sequence it was given.
+
+  Self-consistency, deliberately: "did the model agree with what I told it?" A model asked
+  to score a sequence it was handed in the wrong alphabet cannot agree with it, and no
+  amount of structural signal rescues that. Compare
+  ``test_inspect_conditions_on_the_converted_sequence``, which documents why the *other*
+  reading of recovery -- against the true native -- is insensitive here.
+  """
+  logits = _conditional_logits(structure, sequence)
   return float((jnp.argmax(logits, axis=-1) == sequence).mean())
 
 
@@ -240,4 +253,69 @@ def test_model_consumes_mpnn_not_af(_ubq_structure: dict) -> None:
     f"be impossible while the two alphabets differ, so this test has lost its power to "
     f"discriminate and would pass even with the conversion removed. Do not relax this "
     f"threshold to make it green -- find out why the permutation stopped mattering."
+  )
+
+
+@pytest.mark.alphabet_boundary
+@pytest.mark.requires_weights
+@pytest.mark.slow
+def test_inspect_conditions_on_the_converted_sequence(_ubq_structure: dict) -> None:
+  """``inspect()``'s ``conditional_logits`` must condition on MPNN, matching the factory.
+
+  **This is an exact-equality wiring check, deliberately, and the first version of it was a
+  false green.** The obvious test -- "assert inspect()'s recovery beats chance" -- does not
+  work here, and the reason is worth writing down.
+
+  ``conditional_logits`` sees the structure *and* the sequence, and the structure dominates.
+  Measured on 1UBQ with real proteinmpnn_v_48_020 weights:
+
+  ==========================  ===========================  =========================
+  conditioning fed            recovery vs *true* native    recovery vs *fed* sequence
+  ==========================  ===========================  =========================
+  MPNN (correct)              0.592                        0.592
+  raw AF (the bug)            0.487                        0.118
+  ==========================  ===========================  =========================
+
+  So feeding a permuted sequence degrades recovery 0.592 -> 0.487. It does **not** collapse
+  to chance, and a threshold test at any defensible floor sails straight past it. The widely
+  quoted "0.09, i.e. chance" figure is the *right-hand* column -- self-consistency against
+  whatever was fed -- not evidence that the feature returns noise.
+
+  That does not make the bug benign: the logits answer a different question than the caller
+  asked, so any downstream NLL or per-residue analysis built on them is wrong. It makes the
+  bug **undetectable by the metric everyone reaches for first**, which is exactly why it sat
+  in a shipped CLI command for five weeks (since 2119537, 2026-06-08).
+
+  Hence exact equality against the factory called with the converted sequence. It pins the
+  one thing at issue -- *which sequence runner hands over* -- and it fails the moment the
+  conversion is removed. ``jacobian()`` (``runner.py:1022``) and ``decoded_node_features``
+  (``:840``) share the identical defect; this covers the cheapest to exercise.
+  """
+  from aminx.host.runner import inspect  # noqa: PLC0415
+
+  native_mpnn = af_to_mpnn(_ubq_structure["aatype"]).astype(jnp.int32)
+  length = int(native_mpnn.shape[0])
+
+  reference = _conditional_logits(_ubq_structure, native_mpnn)
+  wrong = _conditional_logits(_ubq_structure, _ubq_structure["aatype"])
+
+  result = inspect(
+    inputs=[str(_UBQ)],
+    inspection_features=["conditional_logits"],
+    checkpoint_id="proteinmpnn_v_48_020",
+  )
+  actual = np.asarray(result["conditional_logits"][0])[:length]  # inspect pads to max_length
+
+  assert np.allclose(actual, np.asarray(reference), atol=1e-4), (
+    "inspect()'s conditional_logits do not match the logits produced by conditioning on "
+    "af_to_mpnn(aatype). runner is handing the model a sequence in the wrong alphabet, so "
+    "the feature answers a different question than the caller asked. This is a shipped CLI "
+    "command (`aminx run inspect`)."
+  )
+  # Proves the check above can fail: the two conditionings really do produce different
+  # logits. Without this, a bug that made both paths identically wrong would pass silently.
+  assert not np.allclose(np.asarray(reference), np.asarray(wrong), atol=1e-4), (
+    "Conditioning on AF and on MPNN produced identical logits, so this test cannot "
+    "distinguish them and proves nothing. Do not delete it -- find out why the sequence "
+    "input stopped mattering."
   )

--- a/tests/utils/test_alphabet_boundary.py
+++ b/tests/utils/test_alphabet_boundary.py
@@ -1,0 +1,200 @@
+"""Pin the two alphabet facts every other module silently assumes.
+
+aminx carries two amino-acid alphabets and marks neither at any boundary:
+
+- **AF** ``ARNDCQEGHILKMFPSTWYVX`` -- what proxide's parsers put in ``aatype``.
+- **MPNN** ``ACDEFGHIKLMNPQRSTVWYX`` -- the model's token space (logits, probs, sampled
+  tokens, ``fixed_tokens``).
+
+They agree only at index 0 (``A``) and 20 (``X``); ~15 of 21 differ. **Every value is legal
+in both**, so no range check, dtype check, or shape check can ever detect a confusion -- it
+produces plausible garbage, never an error. Two guards in this repo prove the point by
+failing to catch anything: ``align.py:563``'s ``jnp.clip(seq, 0, 20)`` and tev_design's
+``if native_aa < 0 or native_aa >= N_AA``. Both pass for every value in both alphabets.
+
+``tests/utils/test_aa_convert.py`` already tests the permutation, and the permutation has
+never been the bug. It tests ``af_to_mpnn`` against itself and never asserts that anything
+*produces* AF or *consumes* MPNN -- so the crossings had zero coverage while five separate
+crossing bugs shipped. **These tests cover the crossings instead.**
+
+Why a distributional check and not a value check: you cannot look at an array and tell which
+alphabet it is in. But you *can* compare against ground truth. A permuted sequence cannot
+fake native recovery -- it lands at chance. That signal needs no type system, survives a
+rename, and reaches across the repo boundary into tev_design, which has none of aminx's
+types. It makes a bad crossing impossible to *ship*, which is weaker than impossible to
+*write*, but five recurrences have already shipped, so shipping is the binding constraint.
+
+**Real parses only, never synthetic fixtures.** A fixture hand-written in the alphabet its
+author assumed can only ever confirm that assumption. That is precisely how the
+``resolve_native_tokens`` bug hid inside the commit whose purpose was preventing it.
+
+task_id: 260715_aminx-campaign-control-knob-audit
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from aminx.utils.aa_convert import AF_ALPHABET, MPNN_ALPHABET, af_to_mpnn
+
+_DATA = Path(__file__).resolve().parents[1] / "data"
+_UBQ = _DATA / "1ubq.pdb"
+
+# 1UBQ's sequence, from the deposition -- external ground truth, not derived from this
+# codebase. The whole point is to check aminx against something aminx did not produce.
+_UBQ_SEQUENCE = (
+  "MQIFVKTLTGKTITLEVEPSDTIENVKAKIQDKEGIPPDQQRLIFAGKQLEDGRTLSDYNIQKESTLHLVLRLRGG"
+)
+
+# Native recovery for ProteinMPNN on a monomer sits near 0.5-0.6; chance over 21 tokens is
+# ~0.05, and a permuted sequence measures ~0.09-0.12 (the permutation is not random -- A and
+# X are fixed points -- so it beats pure chance slightly). These thresholds sit in the wide
+# empty gap between the two regimes, not near either.
+_RECOVERY_FLOOR = 0.40
+_CHANCE_CEILING = 0.25
+
+
+def _decode(aatype: np.ndarray, alphabet: str) -> str:
+  return "".join(alphabet[int(i)] if 0 <= int(i) < len(alphabet) else "?" for i in aatype)
+
+
+def _first_protein(parsed: object) -> object:
+  return parsed if hasattr(parsed, "aatype") else next(iter(parsed))  # type: ignore[call-overload]
+
+
+# ---------------------------------------------------------------------------------------
+# Fact 1: the parsers emit AF. Both ingresses -- there are two, and they are easy to miss.
+# ---------------------------------------------------------------------------------------
+
+
+@pytest.mark.alphabet_boundary
+def test_parse_structure_emits_af_not_mpnn() -> None:
+  """``aminx.io.parsing.parse_structure`` yields AF-ordered ``aatype``.
+
+  Asserts BOTH directions. "AF decodes correctly" alone would still pass if the two
+  alphabets happened to agree on this sequence; requiring MPNN to *fail* proves the test
+  discriminates rather than passing for free.
+  """
+  from aminx.io.parsing import parse_structure  # noqa: PLC0415
+
+  aatype = np.asarray(_first_protein(parse_structure(str(_UBQ))).aatype)  # type: ignore[attr-defined]
+
+  assert _decode(aatype, AF_ALPHABET) == _UBQ_SEQUENCE, (
+    "parse_structure's aatype no longer decodes to 1UBQ's real sequence under the AF "
+    "alphabet. Either the parser's convention changed (in which case every af_to_mpnn call "
+    "in aminx and tev_design is now wrong and must be revisited), or parsing broke."
+  )
+  assert _decode(aatype, MPNN_ALPHABET) != _UBQ_SEQUENCE, (
+    "aatype decodes to the correct sequence under BOTH alphabets, so this test cannot tell "
+    "them apart and proves nothing. Pick a sequence where they differ."
+  )
+
+
+@pytest.mark.alphabet_boundary
+def test_training_ingress_emits_af_not_mpnn() -> None:
+  """``create_protein_dataset`` -- the *other* ingress -- also yields AF.
+
+  This is not redundant with the test above. ``host/prep.py:102`` and
+  ``training/trainer.py:17`` call ``proxide.ops.dataset.create_protein_dataset`` directly and
+  **never touch** ``aminx/io/parsing/dispatch.py``. An audit that checked only the dispatch
+  wrapper concluded aminx had a single parse chokepoint; it has two, and the one it missed is
+  the production inference and training path.
+  """
+  from proxide.ops.dataset import create_protein_dataset  # noqa: PLC0415
+
+  batch = next(iter(create_protein_dataset([str(_UBQ)], batch_size=1)))
+  aatype = np.asarray(batch.aatype).reshape(-1)[: len(_UBQ_SEQUENCE)]
+
+  assert _decode(aatype, AF_ALPHABET) == _UBQ_SEQUENCE, (
+    "The training/inference ingress no longer emits AF. trainer.py feeds this array "
+    "straight into the cross-entropy loss against MPNN-ordered logits, so a change here "
+    "silently changes what every model is trained against."
+  )
+  assert _decode(aatype, MPNN_ALPHABET) != _UBQ_SEQUENCE
+
+
+# ---------------------------------------------------------------------------------------
+# Fact 2: the model consumes MPNN. This is the gate.
+# ---------------------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _ubq_structure() -> dict:
+  from aminx.io.parsing import parse_structure  # noqa: PLC0415
+
+  protein = _first_protein(parse_structure(str(_UBQ)))
+  return {
+    "aatype": jnp.asarray(np.asarray(protein.aatype), dtype=jnp.int32),  # type: ignore[attr-defined]
+    "coordinates": jnp.asarray(np.asarray(protein.coordinates)),  # type: ignore[attr-defined]
+    "mask": jnp.asarray(np.asarray(protein.mask)),  # type: ignore[attr-defined]
+    "residue_index": jnp.asarray(np.asarray(protein.residue_index)),  # type: ignore[attr-defined]
+    "chain_index": jnp.asarray(np.asarray(protein.chain_index)),  # type: ignore[attr-defined]
+  }
+
+
+def _native_recovery(structure: dict, sequence: jnp.ndarray) -> float:
+  """Fraction of positions where the model's argmax equals the supplied sequence.
+
+  Uses ``make_conditional_logits_fn`` deliberately: it is the exact factory
+  ``host/runner.py:774`` uses for the ``conditional_logits`` feature, so this measures the
+  real shipped path rather than a reconstruction of it.
+  """
+  from aminx.io.weights import load_model  # noqa: PLC0415
+  from aminx.sampling.conditional_logits import make_conditional_logits_fn  # noqa: PLC0415
+
+  model = load_model("proteinmpnn_v_48_020")
+  logits_fn = make_conditional_logits_fn(model)
+  logits = jnp.asarray(
+    logits_fn(
+      jax.random.PRNGKey(0),
+      structure["coordinates"],
+      structure["mask"],
+      structure["residue_index"],
+      structure["chain_index"],
+      sequence,
+    ),
+  )
+  if logits.ndim == 3:  # noqa: PLR2004 -- (1, L, 21) vs (L, 21)
+    logits = logits[0]
+  return float((jnp.argmax(logits, axis=-1) == sequence).mean())
+
+
+@pytest.mark.alphabet_boundary
+@pytest.mark.requires_weights
+@pytest.mark.slow
+def test_model_consumes_mpnn_not_af(_ubq_structure: dict) -> None:
+  """The model's token space is MPNN: converting raises recovery from chance to ~0.6.
+
+  **This single test would have caught all five known recurrences** -- resolve_native_tokens,
+  runner.inspect/jacobian, tev_design's native_rank, _token_name, and the trainer. It is the
+  only mechanism available that keys on something real rather than on a name or a type: a
+  permuted sequence cannot fake native recovery.
+
+  Both assertions are load-bearing. The floor catches a broken conversion. The ceiling proves
+  the measurement has power -- without it, a metric that returned a constant 0.6 would pass
+  forever and silently certify nothing. (See ~/.claude/rules/BATHOS.md: verify the
+  measurement against synthetic invariants before trusting it. That rule was written after a
+  temperature-inversion bug burned two hours of hypothesis testing.)
+  """
+  af_native = _ubq_structure["aatype"]
+  mpnn_native = af_to_mpnn(af_native).astype(jnp.int32)
+
+  converted = _native_recovery(_ubq_structure, mpnn_native)
+  raw = _native_recovery(_ubq_structure, af_native)
+
+  assert converted > _RECOVERY_FLOOR, (
+    f"Native recovery through af_to_mpnn is {converted:.3f}, at or near chance. Either the "
+    f"model no longer consumes MPNN, af_to_mpnn broke, or the parser's convention changed. "
+    f"Whichever it is, every conversion call site in aminx and tev_design is now suspect."
+  )
+  assert raw < _CHANCE_CEILING, (
+    f"Feeding the model raw AF aatype scores {raw:.3f}, which is NOT at chance. That should "
+    f"be impossible while the two alphabets differ, so this test has lost its power to "
+    f"discriminate and would pass even with the conversion removed. Do not relax this "
+    f"threshold to make it green -- find out why the permutation stopped mattering."
+  )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aminx"
-version = "0.1.0a16"
+version = "0.1.0a17"
 source = { editable = "." }
 dependencies = [
     { name = "array-record", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
Phase 1 of the aminx campaign control-knob audit (`task_id: 260715_aminx-campaign-control-knob-audit`).

## Why

Over ~5 weeks the downstream necklace TEV campaign hit the **same failure class seven times**: a control knob is declared on the config surface (spec field, CLI flag, manifest key, policy-name string), appears to work, and silently never reaches the model. No crash, structurally valid output. Every one was found *incidentally* during unrelated work; **none by systematic sweep**. Two more surfaced while scoping this PR.

The root cause is structural: `plan_campaign_manifest` builds `row["sampling_spec"]` as a **hand-written 23-key dict literal** (`host/campaign.py:647-681`) with no coupling to `fields(SamplingSpecification)` (88 fields). Nothing enforces the sync, so the drift silently drops newly-added fields — this is what PR #106 fixed one field at a time.

## What this adds

`scripts/audit/knob_matrix.py` — emits **spec field x entry point x hop** by *introspection*, not prose parsing:

- rows: every `dataclasses.fields()` entry on `SamplingSpecification`/`RunSpecification`
- cols: `run` / `spec` / `campaign plan` / `campaign worker` / `campaign ramp-plan` / manifest dict / spec_json encodable / array-coerced-on-decode / read under `host/`
- CLI columns come from click's own param objects; manifest + whitelist columns from AST, not regex

The inventory is mechanical **by design**: an agent recon pass during this work produced a confidently wrong finding (it read a stale local checkout 24 commits behind `origin/main` and concluded the `model_family` fix was present, reasoning that HEAD was chronologically after the commit — it is not an ancestor). Same failure mode that let a wrong `atom_context_num` claim through five review stages. A matrix a script can regenerate is not subject to that.

## Findings at a17 (`3570f0f`)

| | |
|---|---|
| spec fields | 88 |
| manifest dict keys | 23 |
| settable via `campaign plan` | **5** |
| unreachable in campaign mode | **65** |
| → real triage candidates (excl. `init=False` internals, callables, deprecated back-compat) | **52** |

Highlights:
- `ligand_mpnn_use_side_chain_context` is **read nowhere under `host/`** — the script independently rediscovers the `prep.py:133,140` gap where neither `load_model(...)` call site forwards it, so the model is always built with sidechains off regardless of the spec.
- `state_position_map` is on the spec and on spec_json's array whitelist but **never reaches the manifest** (zero matches in `campaign.py`). It works downstream today only because the consumer hand-patches it into row JSON.
- `random_seed`, `multi_state_strategy`, `state_weights`, `tie_group_map`, `bias`, `num_samples`, `sampling_strategy` are all unreachable in campaign mode.

## Validation

Checked against **9 known-answer fields before use**, per the measurement-pipeline rule (verify the instrument on ground truth before trusting a finding). All pass, including the discriminating case: `ligand_context_path` is reachable via `campaign plan` but **not** via `campaign ramp-plan` at the same ref — PR #106 wired `plan` only, leaving the same silent-apo failure reachable through the ramp path. A matrix that passed everything would be broken.

## Scope

Read-only tooling. No `src/` changes, no behavior change. The 52 candidates need individual adjudication (real bug / intentionally excluded *with a written reason* / genuinely N/A in campaign mode) — that triage and the differential harness are follow-ups, as is the regression test that makes drift a red build.

Draft: opening for visibility on the numbers; the exclusion allowlist should land with it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfRSNxK7q3fDbjSAfndT3h