### PR TITLE
chore: bump version 0.1.0a17 -> 0.1.0a18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a17"
+version = "0.1.0a18"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aminx"
-version = "0.1.0a17"
+version = "0.1.0a18"
 source = { editable = "." }
 dependencies = [
     { name = "array-record", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
Version-only bump following the just-merged RunSpec/resolve_decode_mode fix (#108, closes #110/#113) — gives tev_design's vendored wheel pin a distinct, traceable version to point at, matching this project's established per-fix version-bump convention (see `wheels/AMINX_PIN.md` in tev_design).

No code changes beyond `pyproject.toml`/`uv.lock` version strings.