### PR TITLE
fix(training): raise AttributeError from the not-yet-ready stub, unblock torch.compile

### DIFF
--- a/.praxia/docs/audits/260716_proteinebm-parity-report.md
+++ b/.praxia/docs/audits/260716_proteinebm-parity-report.md
@@ -1,7 +1,7 @@
 # ProteinEBM Parity: State of the Port
 
 - **task_id**: `260716_ebm_parity_report`
-- **status**: CORRECTED 2026-07-18 — a real, previously-undiscovered bug meant the PyTorch reference model/tensors never moved to GPU across all 6 benchmark scripts (decoy/ddg/biasing/langevin/langevin_annealing/heterogeneous_batch), despite every result JSON claiming `"device": "cuda"`. Every JAX-vs-PyTorch throughput number this report (and the epic's own founding claim) had ever cited was actually GPU-vs-**CPU**, not the same-hardware comparison it was presented as. Fixed (commit `3faeee6`) and re-run in full on real GPU-vs-GPU hardware (jobs `18284162` + `18293715`, Engaging pi_so3/Blackwell) — see the rewritten §1 for the corrected numbers. Prior status line (2026-07-17): real accuracy-vs-paper data acquired + preliminary correlations measured (§6, unaffected by this bug); `heterogeneous_batch_benchmark`'s JAX crash closed as an open Blackwell/SM120 compiler limitation, confirmed version-independent (jax/jaxlib 0.11.0 retest, job `18161115`) — see §7, still standing, now with an added side-effect noted (the same crash's corrupted CUDA context also takes down PyTorch's two strategies now that PyTorch shares the GPU).
+- **status**: UPDATED 2026-07-19 — §7's open "decoy vs. ddg torch.compile asymmetry" question is resolved (root cause: `aminx.training`'s stub `__getattr__` raised `NotImplementedError` instead of `AttributeError`, breaking `pickle.whichmodule`'s `sys.modules` scan during Inductor's `FxGraphCache` pickling; see §7 for the full trace). Fix in PR #118 (not yet merged). Prior status (2026-07-18): a real, previously-undiscovered bug meant the PyTorch reference model/tensors never moved to GPU across all 6 benchmark scripts (decoy/ddg/biasing/langevin/langevin_annealing/heterogeneous_batch), despite every result JSON claiming `"device": "cuda"`. Every JAX-vs-PyTorch throughput number this report (and the epic's own founding claim) had ever cited was actually GPU-vs-**CPU**, not the same-hardware comparison it was presented as. Fixed (commit `3faeee6`) and re-run in full on real GPU-vs-GPU hardware (jobs `18284162` + `18293715`, Engaging pi_so3/Blackwell) — see the rewritten §1 for the corrected numbers. Prior status line (2026-07-17): real accuracy-vs-paper data acquired + preliminary correlations measured (§6, unaffected by this bug); `heterogeneous_batch_benchmark`'s JAX crash closed as an open Blackwell/SM120 compiler limitation, confirmed version-independent (jax/jaxlib 0.11.0 retest, job `18161115`) — see §7, still standing, now with an added side-effect noted (the same crash's corrupted CUDA context also takes down PyTorch's two strategies now that PyTorch shares the GPU).
 - **author**: orchestrator session (background job)
 - **date**: 2026-07-16
 - **branch**: `worktree-ebm-parity-report`
@@ -324,6 +324,21 @@ data pulled from engaging and committed. Two findings worth noting in the data i
 explained (both scripts wrap the same eager path in `torch.compile`; worth a follow-up look at what
 decoy's compile graph touches that ddg's doesn't). These three scripts' batching charts are now live
 in the artifact (§01b).
+
+**Resolved 2026-07-19 (PR #118, not yet merged):** root-caused via a Dynamo-verbose repro
+(`TORCHDYNAMO_VERBOSE=1`, then calling `decoy_benchmark.py`'s compiled path directly outside its
+try/except). The traceback bottoms out in `self.dump(obj)` — Inductor's `FxGraphCache` pickling a
+compiled artifact — which calls `pickle.whichmodule`, and that scans every entry in `sys.modules`
+via `getattr(module, name, None)` to resolve where an object is defined. `aminx.training`'s stub
+`__getattr__` (`src/aminx/training/__init__.py`) raised `NotImplementedError` for *any* name, which
+breaks the `getattr(obj, name, default)`/`hasattr()` contract that `whichmodule` relies on to
+silently skip modules it can't resolve against — the stub's exception propagates instead, surfacing
+as `BackendCompilerFailed`, unrelated to anything the compiled function itself does. This was never
+about what decoy's compile graph touches that ddg's doesn't — it's that `aminx.training` merely
+needs to be in `sys.modules` (true for any script that does `import aminx`) *and* the specific
+compiled graph needs to hit pickle's slow `whichmodule` scan path (a trivial `torch.compile(lambda
+x: x + 1)` does not; the real `ProteinEBM.compute_energy` graph does). Fix: raise `AttributeError`
+instead — verified via `decoy_benchmark.py --smoke`, all 4 combos now report `compile_error: None`.
 
 **`langevin_benchmark` hit a real crash, not the known autotuning bug**: at length=128, batch=400 —
 the reference's own `run_dynamics.py` default batch size, never tested by decoy/ddg (max batch 256)

--- a/src/aminx/training/__init__.py
+++ b/src/aminx/training/__init__.py
@@ -2,8 +2,9 @@
 
 .. warning::
     The training module has not been updated to use the Sprint 2 composable
-    inference architecture (StageSet / InferencePlan / make_encode_fn). Importing
-    from this module will raise ``NotImplementedError`` until that work is complete.
+    inference architecture (StageSet / InferencePlan / make_encode_fn). Accessing
+    an attribute of this module will raise ``AttributeError`` until that work is
+    complete.
 
     Tracked as Sprint 3 tech debt. The target design mirrors the inference contract:
     a ``TrainingPlan`` (analogous to ``InferencePlan``) with composable loss transforms,
@@ -18,7 +19,15 @@ _TRAINING_NOT_READY = (
 
 
 def __getattr__(name: str) -> object:
-  raise NotImplementedError(_TRAINING_NOT_READY)
+  # AttributeError, not NotImplementedError: a module __getattr__ (PEP 562) must
+  # raise AttributeError so that `getattr(obj, name, default)`/`hasattr` degrade
+  # gracefully. `pickle.whichmodule` scans all of sys.modules via `getattr(mod,
+  # name, None)` when resolving where an object is defined (e.g. Inductor's
+  # FxGraphCache pickling compiled artifacts) -- raising anything else there
+  # crashes torch.compile in-process for any script that merely imports this
+  # module, regardless of whether it ever touches aminx.training on purpose.
+  msg = f"module 'aminx.training' has no attribute {name!r}: {_TRAINING_NOT_READY}"
+  raise AttributeError(msg)
 
 
 __all__: list[str] = []

--- a/tests/training/test_stub_contract.py
+++ b/tests/training/test_stub_contract.py
@@ -1,0 +1,25 @@
+"""Tests for aminx.training's not-yet-ready module stub (PEP 562 __getattr__)."""
+
+from __future__ import annotations
+
+import pytest
+
+import aminx.training
+
+
+def test_attribute_access_raises_attribute_error() -> None:
+  with pytest.raises(AttributeError, match="aminx.training is not yet updated"):
+    aminx.training.anything
+
+
+def test_getattr_with_default_does_not_raise() -> None:
+  # A module __getattr__ (PEP 562) must raise AttributeError, not some other
+  # exception, so that getattr(..., default) and hasattr() degrade gracefully
+  # instead of propagating. This is what pickle.whichmodule relies on when it
+  # scans sys.modules -- see src/aminx/training/__init__.py's __getattr__ docstring.
+  sentinel = object()
+  assert getattr(aminx.training, "anything", sentinel) is sentinel
+
+
+def test_hasattr_returns_false() -> None:
+  assert hasattr(aminx.training, "anything") is False


### PR DESCRIPTION
## Summary

- `aminx.training`'s module `__getattr__` (PEP 562, guarding the not-yet-Sprint-2-ported module) raised `NotImplementedError` for any attribute access. That violates the `getattr(obj, name, default)` / `hasattr()` contract, which specifically catches `AttributeError` to degrade gracefully — anything else propagates.
- This silently broke `torch.compile` for the ProteinEBM benchmark scripts (`scripts/ebm/benchmarks/{decoy,ddg}_benchmark.py`), previously documented in `.praxia/docs/audits/260716_proteinebm-parity-report.md` §7 as an unexplained, unresolved asymmetry ("decoy's torch.compile variant fails 100% of the time... ddg's compiled variant has zero failures... worth a follow-up look").
- Root-caused via a direct Dynamo-verbose repro: Inductor's `FxGraphCache` pickles compiled artifacts, and `pickle.whichmodule` scans all of `sys.modules` via `getattr(module, name, None)` to resolve where an object is defined. Once `aminx.training` is in `sys.modules` (pulled in transitively by `import aminx`), that scan hits the stub and the `NotImplementedError` propagates as a `BackendCompilerFailed` — entirely unrelated to what the compiled function does. This explains why the crash looked erratic/model-dependent rather than a simple import-order issue.
- Fix: raise `AttributeError` instead (message now includes the attribute name, standard convention). The loud "not ready" guard is otherwise unchanged — `aminx.training.anything` still raises immediately with the same descriptive message, just the correct exception type.

## Verification

- `uv run python scripts/ebm/benchmarks/decoy_benchmark.py --smoke`: all 4 length/batch combinations now report `compile_error: None` (previously 4/4 `BackendCompilerFailed`).
- New regression tests (`tests/training/test_stub_contract.py`): attribute access still raises `AttributeError`; `getattr(..., default)` and `hasattr()` now degrade gracefully instead of raising.
- `uv run pytest tests/training/` — 11 passed.
- `uv run ty check src/aminx/training/__init__.py` / `uv run ruff check src/aminx/training/ tests/training/test_stub_contract.py` — clean (no diagnostics introduced; pre-existing baseline diagnostics elsewhere in `training/` are untouched by this change).

## Test plan

- [x] Scoped pytest (`tests/training/`) green
- [x] `ty check` / `ruff check` clean on changed files
- [x] Live repro before/after via `decoy_benchmark.py --smoke`
- [ ] CI (full suite + `ddg_benchmark.py`/other EBM benchmark scripts, not re-run locally per this repo's local-compute guidance)