### PR TITLE
fix(ci): enable git-lfs on checkout after the checkpoint LFS migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       PYTHONDONTWRITEBYTECODE: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/parity-audit.yml
+++ b/.github/workflows/parity-audit.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: aminx
+          lfs: true
 
       - name: Checkout Reference LigandMPNN
         uses: actions/checkout@v4

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: aminx
+          lfs: true
 
       - name: Checkout Reference LigandMPNN
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `.git` history was just migrated to Git LFS (session `260719_trace_aminx_ebm-lfs-merge`): `*.eqx`, `*.eqx.zst`, `*.npz`, `*.array_record`, `*.tar.gz` moved out of plain blobs, shrinking a fresh clone's `.git` from ~536MB to ~66MB.
- `actions/checkout@v4` does not fetch LFS content by default — without this fix, `unit-tests` and both parity workflows would silently check out LFS pointer text instead of real model weights / golden test fixtures, breaking those jobs.
- Added `lfs: true` to the checkout steps that actually need real content: `ci.yml`'s `unit-tests`, and the "Checkout Aminx repository" step in both `parity.yml` and `parity-audit.yml`.
- Left `release.yml` alone (`package-data` only ships `py.typed`, no checkpoints in the built wheel) and `epic-attribution-lint` alone (only scans commit messages, no file content needed).

## Test plan
- [x] YAML syntax validated for all three edited workflow files
- [ ] Confirm `unit-tests` CI run on this PR pulls real LFS content and passes
- [ ] Confirm a `parity.yml` / `parity-audit.yml` run (next scheduled or manually dispatched) resolves golden `.npz` fixtures correctly