### PR TITLE
chore: bump version 0.1.0a18 -> 0.1.0a19 (#121 fusion fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a18"
+version = "0.1.0a19"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
Trivial one-line version bump so a wheel built from post-#121 \`main\` doesn't
collide with the already-vendored pre-fix a18 wheel in tev_design's
\`wheels/\`. No functional change.