### PR TITLE
fix(ebm): add crash isolation to biasing/langevin_annealing benchmarks

### DIFF
--- a/scripts/ebm/benchmarks/biasing_benchmark.py
+++ b/scripts/ebm/benchmarks/biasing_benchmark.py
@@ -443,6 +443,18 @@ def _wall_clock_ms_stats(times_seconds: list[float]) -> tuple[float, float]:
   return float(np.mean(arr_ms)), float(np.std(arr_ms))
 
 
+def _write_rows(out: Path, rows: list[dict[str, Any]]) -> None:
+  """Write accumulated rows so far -- called after every length so a crash mid-sweep
+
+  (e.g. the documented Blackwell/SM120 XLA-autotuning CUDA_ERROR_ILLEGAL_ADDRESS fault,
+  `.praxia/docs/audits/260716_proteinebm-parity-report.md` §7) loses only the in-flight
+  length, not every length already timed.
+  """
+  out.parent.mkdir(parents=True, exist_ok=True)
+  with out.open("w") as f:
+    json.dump(rows, f, indent=2)
+
+
 def _run_dry_run(args: argparse.Namespace, lengths: list[int]) -> int:
   """L1 gate: validate args/paths/imports only -- no model construction, no timing, no network fetches."""
   log.info("[L1 dry-run] Validating args + imports + paths (no model construction, no timing)...")
@@ -535,77 +547,80 @@ def main(argv: list[str] | None = None) -> int:
   rows: list[dict[str, Any]] = []
 
   for length in lengths:
-    log.info("=== length=%d (n_states=%d) ===", length, N_STATES)
-    coords_states_np, aatype_np = _make_synthetic_states(args.seed, length)
-    mask_np = np.ones((length,), dtype=bool)
+    try:
+      log.info("=== length=%d (n_states=%d) ===", length, N_STATES)
+      coords_states_np, aatype_np = _make_synthetic_states(args.seed, length)
+      mask_np = np.ones((length,), dtype=bool)
 
-    coords_states_jax = jnp.asarray(coords_states_np)
-    aatype_jax = jnp.asarray(aatype_np, dtype=jnp.int32)
-    mask_jax = jnp.ones((length,), dtype=bool)
-    t_jax = jnp.asarray(args.diffusion_time)
+      coords_states_jax = jnp.asarray(coords_states_np)
+      aatype_jax = jnp.asarray(aatype_np, dtype=jnp.int32)
+      mask_jax = jnp.ones((length,), dtype=bool)
+      t_jax = jnp.asarray(args.diffusion_time)
 
-    log.info("JAX: warmup + timing energy_evals_per_sec (raw 2-state Vmap dispatch, %d repeats)...", args.n_repeats)
-    jax_throughput, jax_energy_times = _time_jax_throughput(
-      jax_model, coords_states_jax, aatype_jax, t_jax, mask_jax, args.n_repeats,
-    )
-    jax_energy_ms_mean, jax_energy_ms_std = _wall_clock_ms_stats(jax_energy_times)
-    log.info("JAX: warmup + timing diff_fuse_wall_clock_ms (full score_state_difference, %d repeats)...", args.n_repeats)
-    jax_diff_fuse_ms, jax_fuse_times = _time_jax_diff_fuse(
-      jax_model, coords_states_jax, aatype_jax, t_jax, mask_jax, args.n_repeats,
-    )
-    jax_fuse_ms_mean, jax_fuse_ms_std = _wall_clock_ms_stats(jax_fuse_times)
-
-    rows.append(
-      {
-        "protein_length": length,
-        "device": jax_device,
-        "impl": "jax",
-        "energy_evals_per_sec": jax_throughput,
-        "energy_wall_clock_mean_ms": jax_energy_ms_mean,
-        "energy_wall_clock_std_ms": jax_energy_ms_std,
-        "diff_fuse_wall_clock_ms": jax_diff_fuse_ms,
-        "diff_fuse_wall_clock_std_ms": jax_fuse_ms_std,
-      },
-    )
-    log.info(
-      "[jax]     L=%-4d energy_evals_per_sec=%12.2f diff_fuse_wall_clock_ms=%8.3f",
-      length, jax_throughput, jax_diff_fuse_ms,
-    )
-
-    if torch_model is not None:
-      log.info(
-        "PyTorch: warmup + timing energy_evals_per_sec (plain 2-call forward, %d repeats)...", args.n_repeats,
+      log.info("JAX: warmup + timing energy_evals_per_sec (raw 2-state Vmap dispatch, %d repeats)...", args.n_repeats)
+      jax_throughput, jax_energy_times = _time_jax_throughput(
+        jax_model, coords_states_jax, aatype_jax, t_jax, mask_jax, args.n_repeats,
       )
-      torch_throughput, torch_energy_times = _time_pytorch_throughput(
-        torch_model, coords_states_np, aatype_np, args.diffusion_time, mask_np, args.n_repeats, device=torch_device,
+      jax_energy_ms_mean, jax_energy_ms_std = _wall_clock_ms_stats(jax_energy_times)
+      log.info("JAX: warmup + timing diff_fuse_wall_clock_ms (full score_state_difference, %d repeats)...", args.n_repeats)
+      jax_diff_fuse_ms, jax_fuse_times = _time_jax_diff_fuse(
+        jax_model, coords_states_jax, aatype_jax, t_jax, mask_jax, args.n_repeats,
       )
-      torch_energy_ms_mean, torch_energy_ms_std = _wall_clock_ms_stats(torch_energy_times)
-      log.info("PyTorch: warmup + timing diff_fuse_wall_clock_ms (2 calls + subtract, %d repeats)...", args.n_repeats)
-      torch_diff_fuse_ms, torch_fuse_times = _time_pytorch_diff_fuse(
-        torch_model, coords_states_np, aatype_np, args.diffusion_time, mask_np, args.n_repeats, device=torch_device,
-      )
-      torch_fuse_ms_mean, torch_fuse_ms_std = _wall_clock_ms_stats(torch_fuse_times)
+      jax_fuse_ms_mean, jax_fuse_ms_std = _wall_clock_ms_stats(jax_fuse_times)
 
       rows.append(
         {
           "protein_length": length,
-          "device": torch_device,
-          "impl": "pytorch",
-          "energy_evals_per_sec": torch_throughput,
-          "energy_wall_clock_mean_ms": torch_energy_ms_mean,
-          "energy_wall_clock_std_ms": torch_energy_ms_std,
-          "diff_fuse_wall_clock_ms": torch_diff_fuse_ms,
-          "diff_fuse_wall_clock_std_ms": torch_fuse_ms_std,
+          "device": jax_device,
+          "impl": "jax",
+          "energy_evals_per_sec": jax_throughput,
+          "energy_wall_clock_mean_ms": jax_energy_ms_mean,
+          "energy_wall_clock_std_ms": jax_energy_ms_std,
+          "diff_fuse_wall_clock_ms": jax_diff_fuse_ms,
+          "diff_fuse_wall_clock_std_ms": jax_fuse_ms_std,
         },
       )
       log.info(
-        "[pytorch] L=%-4d energy_evals_per_sec=%12.2f diff_fuse_wall_clock_ms=%8.3f",
-        length, torch_throughput, torch_diff_fuse_ms,
+        "[jax]     L=%-4d energy_evals_per_sec=%12.2f diff_fuse_wall_clock_ms=%8.3f",
+        length, jax_throughput, jax_diff_fuse_ms,
       )
 
-  args.out.parent.mkdir(parents=True, exist_ok=True)
-  with args.out.open("w") as f:
-    json.dump(rows, f, indent=2)
+      if torch_model is not None:
+        log.info(
+          "PyTorch: warmup + timing energy_evals_per_sec (plain 2-call forward, %d repeats)...", args.n_repeats,
+        )
+        torch_throughput, torch_energy_times = _time_pytorch_throughput(
+          torch_model, coords_states_np, aatype_np, args.diffusion_time, mask_np, args.n_repeats, device=torch_device,
+        )
+        torch_energy_ms_mean, torch_energy_ms_std = _wall_clock_ms_stats(torch_energy_times)
+        log.info("PyTorch: warmup + timing diff_fuse_wall_clock_ms (2 calls + subtract, %d repeats)...", args.n_repeats)
+        torch_diff_fuse_ms, torch_fuse_times = _time_pytorch_diff_fuse(
+          torch_model, coords_states_np, aatype_np, args.diffusion_time, mask_np, args.n_repeats, device=torch_device,
+        )
+        torch_fuse_ms_mean, torch_fuse_ms_std = _wall_clock_ms_stats(torch_fuse_times)
+
+        rows.append(
+          {
+            "protein_length": length,
+            "device": torch_device,
+            "impl": "pytorch",
+            "energy_evals_per_sec": torch_throughput,
+            "energy_wall_clock_mean_ms": torch_energy_ms_mean,
+            "energy_wall_clock_std_ms": torch_energy_ms_std,
+            "diff_fuse_wall_clock_ms": torch_diff_fuse_ms,
+            "diff_fuse_wall_clock_std_ms": torch_fuse_ms_std,
+          },
+        )
+        log.info(
+          "[pytorch] L=%-4d energy_evals_per_sec=%12.2f diff_fuse_wall_clock_ms=%8.3f",
+          length, torch_throughput, torch_diff_fuse_ms,
+        )
+    except Exception as e:  # noqa: BLE001 -- a single length must not lose already-collected rows
+      log.error("[length=%d] FAILED: %s: %s", length, type(e).__name__, e)
+      rows.append({"protein_length": length, "impl": "error", "error": f"{type(e).__name__}: {e}"})
+
+    _write_rows(args.out, rows)
+
   log.info("Wrote %d rows to %s", len(rows), args.out)
   return 0
 

--- a/scripts/ebm/benchmarks/langevin_annealing_benchmark.py
+++ b/scripts/ebm/benchmarks/langevin_annealing_benchmark.py
@@ -310,40 +310,67 @@ def main() -> int:
   log.info("JAX device: %s | PyTorch device: %s", jax_device, torch_device)
   results = []
   for length in lengths:
-    log.info("=== length=%d ===", length)
-    jax_times = _time_jax_outer_annealing(jax_model, length, args.seed, n_repeats)
-    jax_ms_mean, jax_ms_std = _wall_clock_ms_stats(jax_times)
-    pt_times = _time_pytorch_outer_annealing(ref_model, length, args.seed, n_repeats, device=torch_device)
-    pt_ms_mean, pt_ms_std = _wall_clock_ms_stats(pt_times)
+    try:
+      log.info("=== length=%d ===", length)
+      jax_times = _time_jax_outer_annealing(jax_model, length, args.seed, n_repeats)
+      jax_ms_mean, jax_ms_std = _wall_clock_ms_stats(jax_times)
+      pt_times = _time_pytorch_outer_annealing(ref_model, length, args.seed, n_repeats, device=torch_device)
+      pt_ms_mean, pt_ms_std = _wall_clock_ms_stats(pt_times)
 
-    e10_ms = _time_jax_e10(jax_model, length, args.seed, e10_rounds, e10_batch) * 1000.0
+      e10_ms = _time_jax_e10(jax_model, length, args.seed, e10_rounds, e10_batch) * 1000.0
 
-    results.append({
-      "protein_length": length,
-      "jax_device": jax_device,
-      "pytorch_device": torch_device,
-      "outer_annealing_jax_ms_mean": jax_ms_mean,
-      "outer_annealing_jax_ms_std": jax_ms_std,
-      "outer_annealing_pytorch_ms_mean": pt_ms_mean,
-      "outer_annealing_pytorch_ms_std": pt_ms_std,
-      "outer_annealing_speedup": pt_ms_mean / jax_ms_mean if jax_ms_mean else float("nan"),
-      "e10_pipeline_ms": e10_ms,
-      "e10_rounds": e10_rounds,
-      "e10_batch_size": e10_batch,
-    })
-    log.info(
-      "[length=%d] outer annealing: jax=%.2fms pytorch=%.2fms speedup=%.2fx | e10 pipeline (%d rounds, batch=%d): %.2fms",
-      length, jax_ms_mean, pt_ms_mean, pt_ms_mean / jax_ms_mean if jax_ms_mean else float("nan"),
-      e10_rounds, e10_batch, e10_ms,
-    )
+      results.append({
+        "protein_length": length,
+        "jax_device": jax_device,
+        "pytorch_device": torch_device,
+        "outer_annealing_jax_ms_mean": jax_ms_mean,
+        "outer_annealing_jax_ms_std": jax_ms_std,
+        "outer_annealing_pytorch_ms_mean": pt_ms_mean,
+        "outer_annealing_pytorch_ms_std": pt_ms_std,
+        "outer_annealing_speedup": pt_ms_mean / jax_ms_mean if jax_ms_mean else float("nan"),
+        "e10_pipeline_ms": e10_ms,
+        "e10_rounds": e10_rounds,
+        "e10_batch_size": e10_batch,
+      })
+      log.info(
+        "[length=%d] outer annealing: jax=%.2fms pytorch=%.2fms speedup=%.2fx | e10 pipeline (%d rounds, batch=%d): %.2fms",
+        length, jax_ms_mean, pt_ms_mean, pt_ms_mean / jax_ms_mean if jax_ms_mean else float("nan"),
+        e10_rounds, e10_batch, e10_ms,
+      )
+    except Exception as e:  # noqa: BLE001 -- a single length must not lose already-collected results
+      log.error("[length=%d] FAILED: %s: %s", length, type(e).__name__, e)
+      results.append({"protein_length": length, "error": f"{type(e).__name__}: {e}"})
 
+    _write_payload(args, lengths, n_repeats, e10_rounds, e10_batch, results)
+
+  log.info("Wrote %d result rows to %s", len(results), args.out)
+  return 0
+
+
+def _write_payload(
+  args: argparse.Namespace,
+  lengths: tuple[int, ...],
+  n_repeats: int,
+  e10_rounds: int,
+  e10_batch: int,
+  results: list[dict],
+) -> None:
+  """Write accumulated results so far -- called after every length so a crash mid-sweep
+
+  (e.g. the documented Blackwell/SM120 XLA-autotuning CUDA_ERROR_ILLEGAL_ADDRESS fault,
+  `.praxia/docs/audits/260716_proteinebm-parity-report.md` §7) loses only the in-flight
+  length, not every length already timed.
+  """
   payload = {
     "meta": {
       "smoke": args.smoke,
+      "lengths": list(lengths),
       "noise_schedule": list(DEFAULT_NOISE_SCHEDULE),
       "n_steps_per_level": DEFAULT_N_STEPS_PER_LEVEL,
       "model_swap_threshold": MODEL_SWAP_THRESHOLD,
       "n_repeats": n_repeats,
+      "e10_rounds": e10_rounds,
+      "e10_batch_size": e10_batch,
       "methodology_notes": [
         "Closes a documented gap: langevin_benchmark.py (E11d) only benchmarks "
         "the INNER fixed-t sampler; this script is the first throughput "
@@ -361,14 +388,15 @@ def main() -> int:
         "No SM120 XLA autotuning workaround applied here -- CPU-only local "
         "run. A cluster (GPU) run MUST set "
         "XLA_FLAGS=--xla_gpu_shard_autotuning=false per ~/.claude/rules/CLUSTER.md.",
+        "A row with an 'error' key (no timing fields) means that protein_length "
+        "raised during timing -- all other rows in this file completed normally "
+        "and are unaffected.",
       ],
     },
     "results": results,
   }
   args.out.parent.mkdir(parents=True, exist_ok=True)
   args.out.write_text(json.dumps(payload, indent=2))
-  log.info("Wrote %d result rows to %s", len(results), args.out)
-  return 0
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "aminx"
-version = "0.1.0a18"
+version = "0.1.0a19"
 source = { editable = "." }
 dependencies = [
     { name = "array-record", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
## Summary
- `biasing_benchmark.py` and `langevin_annealing_benchmark.py` were the only 2 of 6 EBM benchmark scripts with no defense against the documented Blackwell/SM120 `CUDA_ERROR_ILLEGAL_ADDRESS` autotuning fault (`.praxia/docs/audits/260716_proteinebm-parity-report.md` §7, confirmed version-independent across jax/jaxlib 0.9.2/0.10.2/0.11.0)
- Both wrote their entire result set once at the very end of `main()` — a mid-sweep crash would silently lose the whole run, the same failure mode `heterogeneous_batch_benchmark.py` and `langevin_benchmark.py` already hit before being hardened
- Mirrors `langevin_benchmark.py`'s proven pattern: per-length `try/except` + incremental write after every length, so a crash loses only the in-flight length

## Why now
Found during a review of the parity report's open items (task `260720_trace-summarize`). External research ([pytorch/pytorch#176426](https://github.com/pytorch/pytorch/issues/176426)) shows the underlying SM120 Triton-codegen defect is a *class* of bug, not confined to the one fused-kernel shape already characterized — so a future length/batch sweep or XLA version bump could trigger it in either of these two currently-unhardened scripts.

## Test plan
- [x] `ty check` clean on both files
- [x] `langevin_annealing_benchmark.py --smoke` real end-to-end run, unchanged output shape
- [x] Injected-failure harness on `langevin_annealing_benchmark.py` (real subprocess run, `SMOKE_LENGTHS` widened to 3, crash forced at length=128): confirmed lengths 64/256 completed and were written despite the length=128 crash
- [x] Injected-failure harness on `biasing_benchmark.py` (monkeypatched model-building since it has no synthetic-smoke path, unlike its sibling): confirmed identical isolation behavior
- [ ] Real cluster re-run of either script (neither has crashed in any observed run yet — this is proactive hardening, not a fix for an active failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)