### PR TITLE
fix(host): calibrate make_sampling_planner's memory estimate with real per-residue bytes

### DIFF
--- a/src/aminx/host/kernel_dispatch.py
+++ b/src/aminx/host/kernel_dispatch.py
@@ -119,16 +119,19 @@ def _sample_batch(
   base_key = _base_sampling_key(spec, grid_lineage=grid_lineage)
   target_num_samples = resolve_target_samples(spec, chunk_sample_count, grid_lineage)
 
+  # seq_len is resolved here (moved ahead of its other former use below) so the
+  # planner's joint-budget memory estimate can be computed against the real
+  # per-structure residue count -- see make_sampling_planner's seq_len docstring.
+  seq_len = batched_ensemble.coordinates.shape[1]
+  batch_size = batched_ensemble.coordinates.shape[0]
+
   # 2. Plan batching
-  batch_plan = make_sampling_planner(spec, n_samples_override=target_num_samples)
+  batch_plan = make_sampling_planner(spec, n_samples_override=target_num_samples, seq_len=seq_len)
 
   structures_bs, samples_bs, temps_bs, noises_bs = extract_batch_sizes(batch_plan)
 
   noises = jnp.asarray(spec.run_spec.sampling.backbone_noise)
   temperatures = jnp.asarray(spec.run_spec.sampling.temperature)
-
-  seq_len = batched_ensemble.coordinates.shape[1]
-  batch_size = batched_ensemble.coordinates.shape[0]
 
   # The unified driver indexes these per-structure arrays by a (possibly traced)
   # structure index under vmap. Convert to JAX arrays so traced indexing lowers to a

--- a/src/aminx/host/plan.py
+++ b/src/aminx/host/plan.py
@@ -168,12 +168,58 @@ class AxisNames:
   N_NOISES = "n_noises"
 
 
+# Conservative per-residue activation footprint (float32 bytes) for one innermost
+# (structure, noise, temperature, sample) combination in the sampling dispatch built
+# by host/kernel_dispatch.py's _sample_batch. Two live tensors dominate:
+#   - the EncoderOutput held for the noise/temp loop (aminx.types.encodings.EncoderOutput:
+#     node_features (L, D), edge_features (L, K, D)) -- same shape family as, and reusing
+#     the same conservative D=128/K=32/D_edge=48 constants already established by
+#     aminx.sampling.conditional_logits._plan_axis_strategy's callers for this exact type
+#     (see batched_encode_fn's `activation_bytes = seq_len * (128 + 32 * 48) * 4`), not a
+#     fresh guess;
+#   - the per-sample decode output (res.logits, shape (L, 21)) -- same convention as
+#     conditional_logits.py's batched_decode_fn (`seq_len * 21 * 4`).
+# estimate_memory_theoretical's single flat product (see aminx.tiling.planner) does not
+# distinguish "computed once per noise/temp" from "computed once per sample" -- summing
+# both into one per-element constant is the conservative choice given that architecture,
+# not an attempt to model exact live-tensor accounting.
+_SAMPLING_NODE_FEATURE_DIM = 128
+_SAMPLING_EDGE_NEIGHBORS = 32
+_SAMPLING_EDGE_FEATURE_DIM = 48
+_SAMPLING_DECODE_VOCAB = 21
+_SAMPLING_BYTES_PER_ELEMENT = 4  # float32
+
+
+def _sampling_activation_bytes_per_element(seq_len: int) -> float:
+  """Conservative per-residue activation-byte estimate for one sampling dispatch unit.
+
+  See the module-level constants above for the shape/constant provenance. Used as
+  ``estimate_memory_theoretical``'s ``base_shape_bytes`` argument in
+  ``make_sampling_planner`` -- previously hardcoded to ``1.0`` (a dimensionless
+  placeholder, off by ~7-8 orders of magnitude from a real device memory budget for
+  a realistic samples/temperatures/noises composition), which made the joint-budget
+  Vmap-vs-SafeMap demotion check for those three axes practically inert regardless of
+  real activation size (found investigating the E11e heterogeneous-batch benchmark
+  session, 2026-07-23; git-blame traces the ``1.0`` to the 2026-07-06 joint-budget
+  migration, commit 35dc18b8, inherited unreviewed from the pre-migration local
+  planner -- see .praxia/docs/specs/260706_epic1541-planner-joint-budget-migration.md,
+  which never discusses base_shape_bytes/activation_multiplier calibration).
+  """
+  per_residue_elements = (
+    _SAMPLING_NODE_FEATURE_DIM
+    + _SAMPLING_EDGE_NEIGHBORS * _SAMPLING_EDGE_FEATURE_DIM
+    + _SAMPLING_DECODE_VOCAB
+  )
+  return seq_len * per_residue_elements * _SAMPLING_BYTES_PER_ELEMENT
+
+
 def make_sampling_planner(
   spec: SamplingSpecification,
   param_bytes: float = 0.0,
   headroom: float = 0.80,
   activation_multiplier: float = 2.5,
   n_samples_override: int | None = None,
+  seq_len: int | None = None,
 ) -> BatchPlan:
   """Create a BatchPlan for _sample_batch dispatch with advisory logging.
 
@@ -210,6 +256,18 @@ def make_sampling_planner(
       with callers/tests that construct a plan without a real per-call
       sample count in hand; the one production call site
       (``host/kernel_dispatch.py``'s ``_sample_batch``) always passes it.
+  seq_len : int | None, optional
+      Real per-structure residue count, e.g. from
+      ``batched_ensemble.coordinates.shape[1]``. Used to compute a real
+      per-element activation-byte estimate for the joint memory-budget check
+      (see ``_sampling_activation_bytes_per_element``) instead of the
+      previous hardcoded ``base_shape_bytes=1.0`` placeholder, which made the
+      budget check practically inert for the samples/temperatures/noises
+      axes regardless of real activation size. Defaults to ``None`` (falls
+      back to the old ``1.0`` placeholder) only for backward compatibility
+      with callers/tests that construct a plan without a real structure in
+      hand; the one production call site (``host/kernel_dispatch.py``'s
+      ``_sample_batch``) always passes it.
 
   Returns
   -------
@@ -235,10 +293,11 @@ def make_sampling_planner(
     ),
     dataclasses.replace(N_NOISES, cardinality=max(1, len(getattr(spec, "backbone_noise", [0.0])))),
   ]
+  base_shape_bytes = 1.0 if seq_len is None else _sampling_activation_bytes_per_element(seq_len)
   return _plan_with_joint_budget(
     axes,
     budget_bytes=budget_bytes,
-    estimate_fn=lambda ds: estimate_memory_theoretical(ds, 1.0, activation_multiplier),
+    estimate_fn=lambda ds: estimate_memory_theoretical(ds, base_shape_bytes, activation_multiplier),
     carry_specs=getattr(spec, "carry_specs", None) or [],
     dedup_specs=getattr(spec, "dedup_specs", None) or [],
   )


### PR DESCRIPTION
## Summary

- `make_sampling_planner`'s joint-budget memory estimate called `estimate_memory_theoretical(ds, 1.0, activation_multiplier)` — `base_shape_bytes` hardcoded to `1.0`, a dimensionless placeholder, not a real per-element byte size.
- For a realistic samples/temperatures/noises composition (e.g. 128 x 4 x 3), the resulting "byte estimate" comes out around 3840, compared to a real device memory budget around 1e11 bytes — off by 7-8 orders of magnitude. The joint-budget Vmap-vs-SafeMap demotion check for `N_SAMPLES`/`N_TEMPERATURES`/`N_NOISES` was therefore structurally present but practically inert, regardless of real activation size. (`N_STRUCTURES`/`n_states` are separately protected via `_HETEROGENEOUS_AXIS_NAMES` — this bug was specific to the other three axes.)
- `git blame` traces `base_shape_bytes=1.0` to the 2026-07-06 joint-budget migration (`35dc18b8`), inherited unreviewed from the pre-migration local planner — `.praxia/docs/specs/260706_epic1541-planner-joint-budget-migration.md` never discusses `base_shape_bytes`/`activation_multiplier` calibration.
- Found investigating an unrelated production-scale OOM benchmark session (2026-07-23); confirmed as a real, separate bug (not the additive-vs-multiplicative arithmetic error initially hypothesized — the multiplication itself, in `estimate_memory_theoretical`, is correct).
- This is the complementary piece to #127 (`fix/state-axis-vmap-blowup`), which deliberately routed the `N_STATES` axis around this same memory-estimator path "since an optimistic byte estimate is exactly what let this bug go unnoticed." This fix makes the estimator itself trustworthy for the axes that still use it.

## Fix

- `make_sampling_planner` gains an optional `seq_len` parameter (`None` preserves the prior `1.0` placeholder, for backward compatibility with callers/tests that construct a plan without a real structure in hand).
- New `_sampling_activation_bytes_per_element(seq_len)` helper computes a real per-residue byte estimate, derived from `aminx.types.encodings.EncoderOutput`'s actual field shapes (`node_features (L, D)`, `edge_features (L, K, D)`) plus the per-sample decode logits shape `(L, 21)` — reusing the **same** conservative `D=128`/`K=32`/`D_edge=48` constants already established and used in production by `aminx.sampling.conditional_logits._plan_axis_strategy`'s callers for this exact `EncoderOutput` type, and the same decode-logits convention — not a fresh guess.
- `host/kernel_dispatch.py`'s `_sample_batch` now resolves `seq_len` before calling `make_sampling_planner` (previously computed a few lines later, unused by the planner) and threads it through — the one production call site.

## Test plan
- [x] `ty check` / `ruff check` diagnostic counts unchanged vs `main` (17/116, confirmed via `git stash` A/B comparison)
- [x] `ruff format` intentionally NOT run file-wide on `kernel_dispatch.py` — it would also reformat unrelated pre-existing debt (confirmed present on `main` too via the same A/B comparison); kept the diff surgical instead of bundling unrelated cleanup
- [x] 25/25 relevant tests pass: `tests/host/test_t_planner_gate_parity.py`, `test_samples_cardinality_fix.py`, `test_sampling_planner_carry_dedup.py`, `test_kernel_dispatch_atom37_wiring.py`, `test_kernel_dispatch_state_position_map_wiring.py`