### PR TITLE
harden EBM alphabet + contacts eval-path against silent regressions

### DIFF
--- a/scripts/ebm/checkpoint_parity_check.py
+++ b/scripts/ebm/checkpoint_parity_check.py
@@ -232,6 +232,54 @@ def _jax_energy_and_score(
   )
 
 
+def _reference_energy_default_contacts(
+  ref_model: "ProteinEBM",
+  fixed_input: dict[str, np.ndarray],
+  t: float,
+) -> np.ndarray:
+  """Reference total energy with ``external_contacts`` left to its OWN default.
+
+  Passes ``external_contacts=None`` so the reference's ``forward`` applies its
+  built-in default (``ebm.py:167-169``: all-ones for the 3-way contact variant
+  this checkpoint uses). Paired with the JAX side's ``contacts=None`` this
+  proves the ported model's default now matches the reference default -- the
+  gap that PR #130's harness had to paper over by passing ``contacts=ones``
+  explicitly at every call site.
+  """
+  import torch  # noqa: PLC0415
+
+  r_noisy = torch.tensor(fixed_input["coords_scaled"], dtype=torch.float32).unsqueeze(0)
+  input_feats = {
+    "r_noisy": r_noisy,
+    "aatype": torch.tensor(fixed_input["aatype"], dtype=torch.long).unsqueeze(0),
+    "residue_idx": torch.tensor(fixed_input["residue_index"], dtype=torch.long).unsqueeze(0),
+    "mask": torch.tensor(fixed_input["residue_mask"], dtype=torch.bool).unsqueeze(0),
+    "t": torch.tensor([t], dtype=torch.float32),
+    "chain_encoding": torch.tensor(fixed_input["chain_id"], dtype=torch.long).unsqueeze(0),
+    "external_contacts": None,
+  }
+  model_out = ref_model.compute_energy(input_feats, rescale_input_coords=False)
+  return model_out["energy"].detach().numpy().reshape(())
+
+
+def _jax_energy_default_contacts(
+  ported_model: "ProteinEBMModel",
+  fixed_input: dict[str, np.ndarray],
+  t: float,
+) -> np.ndarray:
+  """Ported JAX total energy with ``contacts=None`` (its own resolved default)."""
+  energy = ported_model.energy(
+    jnp.asarray(fixed_input["coords_scaled"]),
+    jnp.asarray(fixed_input["aatype"], dtype=jnp.int32),
+    jnp.asarray(t),
+    jnp.asarray(fixed_input["residue_mask"]),
+    contacts=None,
+    residue_index=jnp.asarray(fixed_input["residue_index"], dtype=jnp.int32),
+    chain_id=jnp.asarray(fixed_input["chain_id"], dtype=jnp.int32),
+  )
+  return np.asarray(energy)
+
+
 def _report_allclose(label: str, ref: np.ndarray, jax_val: np.ndarray, atol: float, rtol: float) -> bool:
   diff = np.abs(ref - jax_val)
   max_abs = float(np.max(diff))
@@ -308,6 +356,31 @@ def main() -> int:
   log.info("[%s] masked-residue energy == 0 (reference): %s", "PASS" if masked_ref_zero else "FAIL", masked_ref_zero)
   log.info("[%s] masked-residue energy == 0 (ported JAX): %s", "PASS" if masked_jax_zero else "FAIL", masked_jax_zero)
   results["masked_residue_zero_energy"] = masked_ref_zero and masked_jax_zero
+
+  # Default-contacts parity (Track B / PR #130 follow-up): the port's
+  # contacts=None now resolves to the reference default (all-ones for the num=3
+  # checkpoint), so running BOTH sides with their own defaults must agree. This
+  # is separate from the explicit-zeros cases above (which pin identical inputs)
+  # -- it proves the *defaults themselves* are now reference-faithful, closing
+  # the gap that forced every harness call site to pass contacts=ones by hand.
+  # Guarded so a reference-API mismatch degrades to a WARNING rather than
+  # breaking the (independent) explicit-contacts parity.
+  try:
+    ref_energy_default = _reference_energy_default_contacts(ref_model, fixed_input, args.diffusion_time)
+    jax_energy_default = _jax_energy_default_contacts(ported_model, fixed_input, args.diffusion_time)
+    results["default_contacts_energy"] = _report_allclose(
+      "default_contacts total_energy (contacts=None both sides)",
+      ref_energy_default,
+      jax_energy_default,
+      args.atol,
+      args.rtol,
+    )
+  except Exception as exc:  # noqa: BLE001 -- diagnostic guard: must not break the primary parity
+    log.warning(
+      "Default-contacts parity case could not run (reference API mismatch?): %s. "
+      "Skipping this sub-check; the explicit-contacts parity above is unaffected.",
+      exc,
+    )
 
   all_pass = all(results.values())
   log.info("=== OVERALL: %s ===", "PASS" if all_pass else "FAIL")

--- a/scripts/ebm/real_ddg_stability_benchmark.py
+++ b/scripts/ebm/real_ddg_stability_benchmark.py
@@ -138,6 +138,8 @@ def _score_one_assay(
 
   mask = wildtype.mask
   # external_contacts = ones (num_contact_embeddings == 3 -> ebm.py:167-169 default is ones).
+  # As of the Track-B trunk change, contacts=None now resolves to ones for the num=3 checkpoint too;
+  # this explicit array is redundant-but-defensive (kept as a self-documenting pin).
   contacts = jnp.ones((n_res,), dtype=jnp.int32)
   t = jnp.asarray(PINNED_T)
   # Center the folded template (unfolded members are already mean-centered + scaled). Self-conditioning

--- a/scripts/ebm/real_decoy_ranking_benchmark.py
+++ b/scripts/ebm/real_decoy_ranking_benchmark.py
@@ -166,8 +166,10 @@ def _score_one_native(
   # deterministic score.)
   coords = coords - jnp.mean(coords, axis=1, keepdims=True)
   # external_contacts = ones: the checkpoint has num_contact_embeddings == 3, so the reference's
-  # compute_energy defaults external_contacts to ONES (ebm.py:167-169), not zeros. aminx's model
-  # defaults contacts=None to zeros, which selects the wrong contact-embedding row for every residue.
+  # compute_energy defaults external_contacts to ONES (ebm.py:167-169), not zeros.
+  # NOTE: as of the Track-B trunk change, model.energy(contacts=None) now ALSO resolves to ones for
+  # the num=3 checkpoint, so this explicit array is redundant; kept as a defensive, self-documenting
+  # pin so the harness stays correct regardless of the library default.
   contacts = jnp.ones((n_res,), dtype=jnp.int32)
   quality = np.asarray(tmscores)
 

--- a/src/aminx/ebm/ddg_stability.py
+++ b/src/aminx/ebm/ddg_stability.py
@@ -77,13 +77,26 @@ index vocabulary matches the rest of aminx's MPNN-style alphabet
 (``aminx.utils.aa_convert.MPNN_ALPHABET`` = ``"ACDEFGHIKLMNPQRSTVWYX"``, ``X``
 = mask/unknown at index 20), consistent with
 ``aminx.ebm.contracts.AAType``'s documented "21-way embedding incl. mask
-token 20" contract. **Caveat, stated plainly:** whether the ProteinEBM
-reference checkpoint's ``sequence_embedding`` table was actually trained
-against *this exact* letter ordering was not independently verified anywhere
-in this epic so far (E3.5's parity gate validates shapes/values on
-arbitrary/random ``aatype`` integers, not the semantic letter-to-index
-mapping) -- this module inherits that same, already-existing assumption
-rather than introducing a new one.
+token 20" contract.
+
+**RESOLVED (PR #130) -- and a trap this module still carries.** The ProteinEBM
+``sequence_embedding`` table consumes **AlphaFold order**
+(``aminx.utils.aa_convert.AF_ALPHABET``), verified against the reference
+``restypes`` and pinned by ``tests/ebm/test_alphabet_boundary_ebm.py`` +
+``aminx.ebm.model.InputEmbeddings``'s embedding-lookup docstring. But this
+module's CA loader (``load_ca_backbone_from_pdb``) and mutant helpers
+(``make_point_mutants``/``random_point_mutants``) still emit **MPNN order**
+(``MPNN_ALPHABET``). Their output is therefore **NOT** safe to feed straight
+into ``model.energy``/``score_mutant_ensemble`` -- doing so selects the wrong
+embedding row for ~15/21 residues (the exact PR #130 accuracy defect). The
+correct, reference-faithful path converts to AF order first
+(``protein_sequence_to_string`` -> ``sequence_to_af_aatype``), which is what
+the accuracy harness ``scripts/ebm/real_ddg_stability_benchmark.py`` does.
+``compute_ddg_stability`` below still runs on this module's MPNN-order aatype
+and is retained only for the wiring/degeneracy sanity checks in
+``tests/ebm/test_ddg_stability.py`` (which assert relative comparisons that
+survive the ordering); it does **not** reproduce the paper Spearman and must
+not be treated as the accuracy path.
 """
 
 from __future__ import annotations
@@ -218,7 +231,13 @@ def load_ca_backbone_from_pdb(
   coords = jnp.asarray(coords_angstrom) * _COORDINATE_SCALING
   aatype = jnp.asarray(aatype_np)
   mask = jnp.ones((len(residues),), dtype=bool)
-  return WildtypeStructure(coords=coords, aatype=aatype, mask=mask, residue_ids=residue_ids, sasa=sasa_tuple)
+  return WildtypeStructure(
+    coords=coords,
+    aatype=aatype,
+    mask=mask,
+    residue_ids=residue_ids,
+    sasa=sasa_tuple,
+  )
 
 
 def identify_buried_hydrophobic_positions(
@@ -404,14 +423,22 @@ _C_N_CA_ANGLE = np.radians(121.7)
 # ramachandran_file is supplied -- which is exactly how the reference's own ddg_prediction.ipynb
 # calls generate_random_backbone_coords: no file, uniform_sampling=True). Only this fallback path
 # is ported; the file-based branch is dead code for this use case and is not ported.
-_RAMACHANDRAN_REGIONS_DEFAULT: tuple[tuple[float, float], ...] = ((-60.0, 30.0), (-120.0, 120.0), (60.0, 30.0))
+_RAMACHANDRAN_REGIONS_DEFAULT: tuple[tuple[float, float], ...] = (
+  (-60.0, 30.0),
+  (-120.0, 120.0),
+  (60.0, 30.0),
+)
 _RAMACHANDRAN_REGIONS_GLY: tuple[tuple[float, float], ...] = ((-60.0, 30.0), (60.0, 30.0))
 _RAMACHANDRAN_REGIONS_PRO: tuple[tuple[float, float], ...] = ((-60.0, 30.0),)
 
 
 def _place_atom(
-  p1: np.ndarray, p2: np.ndarray, p3: np.ndarray,
-  bond_length: float, bond_angle: float, dihedral_angle: float,
+  p1: np.ndarray,
+  p2: np.ndarray,
+  p3: np.ndarray,
+  bond_length: float,
+  bond_angle: float,
+  dihedral_angle: float,
 ) -> np.ndarray:
   """Place a 4th atom given 3 prior atoms + bond length/angle/dihedral (NeRF-style placement).
 
@@ -514,20 +541,64 @@ def generate_real_unfolded_ensemble(
 
     if n_residues > 1:
       omega0 = 0.0
-      coords[1, 0] = _place_atom(coords[0, 0], coords[0, 1], coords[0, 2], _C_N_LENGTH, _CA_C_N_ANGLE, omega0)
+      coords[1, 0] = _place_atom(
+        coords[0, 0],
+        coords[0, 1],
+        coords[0, 2],
+        _C_N_LENGTH,
+        _CA_C_N_ANGLE,
+        omega0,
+      )
       phi, psi = _sample_backbone_dihedral(sequence[1], rng)
-      coords[1, 1] = _place_atom(coords[0, 1], coords[0, 2], coords[1, 0], _N_CA_LENGTH, _C_N_CA_ANGLE, phi)
-      coords[1, 2] = _place_atom(coords[0, 2], coords[1, 0], coords[1, 1], _CA_C_LENGTH, _N_CA_C_ANGLE, psi)
+      coords[1, 1] = _place_atom(
+        coords[0, 1],
+        coords[0, 2],
+        coords[1, 0],
+        _N_CA_LENGTH,
+        _C_N_CA_ANGLE,
+        phi,
+      )
+      coords[1, 2] = _place_atom(
+        coords[0, 2],
+        coords[1, 0],
+        coords[1, 1],
+        _CA_C_LENGTH,
+        _N_CA_C_ANGLE,
+        psi,
+      )
 
     for i in range(2, n_residues):
       phi, psi = _sample_backbone_dihedral(sequence[i], rng)
       omega = rng.normal(0.0, 0.1)
-      coords[i, 0] = _place_atom(coords[i - 1, 0], coords[i - 1, 1], coords[i - 1, 2], _C_N_LENGTH, _CA_C_N_ANGLE, omega)
-      coords[i, 1] = _place_atom(coords[i - 1, 1], coords[i - 1, 2], coords[i, 0], _N_CA_LENGTH, _C_N_CA_ANGLE, phi)
-      coords[i, 2] = _place_atom(coords[i - 1, 2], coords[i, 0], coords[i, 1], _CA_C_LENGTH, _N_CA_C_ANGLE, psi)
+      coords[i, 0] = _place_atom(
+        coords[i - 1, 0],
+        coords[i - 1, 1],
+        coords[i - 1, 2],
+        _C_N_LENGTH,
+        _CA_C_N_ANGLE,
+        omega,
+      )
+      coords[i, 1] = _place_atom(
+        coords[i - 1, 1],
+        coords[i - 1, 2],
+        coords[i, 0],
+        _N_CA_LENGTH,
+        _C_N_CA_ANGLE,
+        phi,
+      )
+      coords[i, 2] = _place_atom(
+        coords[i - 1, 2],
+        coords[i, 0],
+        coords[i, 1],
+        _CA_C_LENGTH,
+        _N_CA_C_ANGLE,
+        psi,
+      )
 
     ca = coords[:, 1, :]
-    members[member_idx] = ((ca - ca.mean(axis=0, keepdims=True)) * coordinate_scaling).astype(np.float32)
+    members[member_idx] = ((ca - ca.mean(axis=0, keepdims=True)) * coordinate_scaling).astype(
+      np.float32,
+    )
 
   return jnp.asarray(members)
 
@@ -577,7 +648,11 @@ def unfolded_state_correction(
   def _score_one(c: Coords) -> Energy:
     return model.energy(c, aatype, t, mask)
 
-  ensemble_energies: EnergyVector = dispatch_axis(decision.strategy, _score_one, unfolded_coords_ensemble)
+  ensemble_energies: EnergyVector = dispatch_axis(
+    decision.strategy,
+    _score_one,
+    unfolded_coords_ensemble,
+  )
   return mean_fuse(ensemble_energies)
 
 

--- a/src/aminx/ebm/model.py
+++ b/src/aminx/ebm/model.py
@@ -21,12 +21,15 @@ each individually gated/no-op in the reference too:
 * ``atom_mask_embedding`` / all sidechain-diffusion machinery is **dropped**
   (``diffuse_sidechain = False`` in both shipped configs; out of scope for
   E0-E7 per design spec §1 Fork 5).
-* ``external_contacts`` always defaults to the all-zeros "no external
-  contact" category (design spec §1) -- the reference's
-  ``num_contact_embeddings == 3 -> default ones`` special case (a 3-way
-  contact-type variant, ``ebm.py:169``) is not reproduced; only the 2-way
-  (no-contact / has-contact) default-zero behavior is, matching the
-  documented MVP contract.
+* ``external_contacts`` defaults to match the reference exactly
+  (``ebm.py:167-169``): all-**ones** when ``num_contact_embeddings == 3``
+  (the 3-way contact-type variant the shipped checkpoint uses), all-**zeros**
+  ("no external contact") otherwise. The default is resolved in
+  :meth:`ProteinEBMModel.trunk_features` by reading the contact embedding
+  table's row count, so callers no longer have to pass ``contacts=ones``
+  explicitly on the num=3 checkpoint to be reference-faithful. Guarded by
+  ``tests/ebm/test_model.py::TestContactsDefaultFallback`` (both the 2-way
+  zeros and 3-way ones cases).
 
 ``use_self_conditioning`` (default ``True`` in the shipped configs) **is**
 included: :class:`InputEmbeddings` always builds a
@@ -125,8 +128,9 @@ if TYPE_CHECKING:
 DATA_DIMENSION = 3
 
 # Default number of contact-embedding categories (the reference's 2-way
-# no-contact/has-contact variant; the 3-way variant's ones-default special
-# case is not reproduced -- see module docstring).
+# no-contact/has-contact variant). The contacts=None default is now resolved
+# per-variant in ``trunk_features`` (zeros for 2-way, ones for the 3-way
+# checkpoint variant), matching the reference -- see module docstring.
 DEFAULT_NUM_CONTACT_EMBEDDINGS = 2
 
 
@@ -173,7 +177,10 @@ class InputEmbeddings(eqx.Module):
     self.noisy_coord_embedding = eqx.nn.Linear(data_dimension, token_s, use_bias=False, key=k_coord)
     self.contact_embedding = eqx.nn.Embedding(num_contact_embeddings, token_s, key=k_contact)
     self.self_conditioning_embedding = eqx.nn.Linear(
-      data_dimension, token_s, use_bias=False, key=k_selfcond,
+      data_dimension,
+      token_s,
+      use_bias=False,
+      key=k_selfcond,
     )
 
   def __call__(
@@ -183,7 +190,17 @@ class InputEmbeddings(eqx.Module):
     contacts: jax.Array,  # int, shape (N,); see module docstring re: bare-identifier jaxtyping shapes
     sc_coords: Coords,
   ) -> Float[Array, "N four_token_s"]:
-    """Concatenate the four embedding heads into one per-residue vector, dim ``4*token_s``."""
+    """Concatenate the four embedding heads into one per-residue vector, dim ``4*token_s``.
+
+    CONTRACT: ``aatype`` must be **AlphaFold2-ordered** (``AF_ALPHABET``,
+    ``aminx.utils.aa_convert``). This is a direct per-row ``Embedding`` lookup
+    with no ordering conversion -- the row selected is fixed entirely by the
+    caller. Feeding ProteinMPNN-ordered indices selects the wrong row for
+    ~15/21 residues and silently destroys accuracy (the PR #130 regression).
+    Callers arrive at AF-order via ``parse_structure`` (already AF) or
+    ``sequence_to_af_aatype`` (string->AF). Guarded by
+    ``tests/ebm/test_alphabet_boundary_ebm.py``.
+    """
     sequence_emb = jax.vmap(self.sequence_embedding)(aatype)
     coord_emb = jax.vmap(self.noisy_coord_embedding)(r_noisy)
     contact_emb = jax.vmap(self.contact_embedding)(contacts)
@@ -266,7 +283,10 @@ class ProteinEBMModel(eqx.Module):
     k_embed, k_single, k_relpos, k_pairwise, k_transformer, k_readouts = jax.random.split(key, 6)
 
     self.input_embeddings = InputEmbeddings(
-      token_s, num_contact_embeddings, DATA_DIMENSION, key=k_embed,
+      token_s,
+      num_contact_embeddings,
+      DATA_DIMENSION,
+      key=k_embed,
     )
 
     # Always sequence_emb + coord_emb + contact_emb + self_cond_emb == 4 heads
@@ -328,7 +348,10 @@ class ProteinEBMModel(eqx.Module):
 
     Defaults mirror ``ProteinEBM.forward`` (``ebm.py:163-196``):
 
-    * ``contacts=None`` -> all-zeros ("no external contact"; design spec §1).
+    * ``contacts=None`` -> all-ones when ``num_contact_embeddings == 3`` (the
+      shipped checkpoint's 3-way contact variant), all-zeros otherwise --
+      matching ``ProteinEBM.forward``'s default (``ebm.py:167-169``). The row
+      count is read from ``self.input_embeddings.contact_embedding``.
     * ``sc_coords=None`` -> ``jnp.zeros_like(coords)`` (``ebm.py:194``'s
       ``sc_coords if sc_coords is not None else torch.zeros_like(r_noisy)``).
     * ``residue_index=None`` -> ``jnp.arange(N)`` (sequential residue
@@ -340,7 +363,16 @@ class ProteinEBMModel(eqx.Module):
     """
     n = coords.shape[0]
     if contacts is None:
-      contacts = jnp.zeros((n,), dtype=jnp.int32)
+      # Reference-aligned default (ebm.py:167-169): ProteinEBM.forward defaults
+      # external_contacts to all-ONES for the 3-way contact variant
+      # (num_contact_embeddings == 3), all-zeros otherwise ("no external
+      # contact"). num_contact_embeddings is not stored as a model field, so
+      # recover it from the contact embedding table's row count. This makes the
+      # shipped num=3 checkpoint match the reference default without every
+      # caller having to pass contacts=ones explicitly (see B-track guardrail).
+      n_contact = self.input_embeddings.contact_embedding.num_embeddings
+      contact_fill = 1 if n_contact == 3 else 0
+      contacts = jnp.full((n,), contact_fill, dtype=jnp.int32)
     if sc_coords is None:
       sc_coords = jnp.zeros_like(coords)
     if residue_index is None:

--- a/tests/ebm/test_alphabet_boundary_ebm.py
+++ b/tests/ebm/test_alphabet_boundary_ebm.py
@@ -1,0 +1,227 @@
+"""Alphabet-boundary guardrail for the ProteinEBM ``sequence_embedding`` path.
+
+**Why this file exists.** The PR #130 accuracy regression was an AA-alphabet
+permutation: the eval harness fed ProteinMPNN-ordered residue indices into the
+AlphaFold2-ordered ``sequence_embedding`` table (``model.py:187``), selecting
+the wrong embedding row for ~15/21 residues. It survived every existing gate
+because none of them pin the fact that the EBM consumes **AF-order**:
+
+* ``scripts/ebm/checkpoint_parity_check.py`` feeds identical *random* ints to
+  both the JAX port and the PyTorch reference -- both agree on any integer->row
+  mapping, so it is alphabet-agnostic by construction.
+* ``tests/ebm/test_ddg_stability.py::TestRealCheckpointDestabilizingMutationSanity``
+  asserts a disruptive-vs-conservative ``|ddG diff| > 2.0``. That is a
+  *degeneracy* check (two distinct embedding rows score differently) -- it is
+  satisfied under the WRONG alphabet too, so it cannot discriminate ordering.
+* Every other EBM test uses random ints, all-zeros, or asserts no accuracy.
+
+**The discriminator used here.** A signal that discriminates alphabet
+correctness must be *sequence-embedding-meaning-dependent at fixed structure*
+-- not a structure-quality signal (energy-vs-RMSD) or a two-row degeneracy
+signal, both of which partly survive a scrambled alphabet. The clean probe is
+**native-sequence preference**: on a fixed native backbone, a trained EBM
+assigns lower energy to the correct native sequence (AF-order) than to the
+same residues fed in the WRONG order (``af_to_mpnn(native)`` -- exactly the
+PR #130 bug), and lower than random shuffles of the native sequence. When the
+alphabet is wrong, that preference collapses -- the mis-ordered sequence looks
+like just another random sequence. This is the "assert-correct AND assert-
+wrong-fails" discrimination pattern of ``tests/utils/test_alphabet_boundary.py``
+(the ProteinMPNN-side analogue), applied to the EBM side.
+
+Skipped unless the real E3.5-ported orbax checkpoint is present (not committed;
+see ``scripts/ebm/checkpoint_parity_check.py``). Marked ``slow`` +
+``requires_weights`` -- deselected by default (``addopts`` in pyproject), run
+explicitly (``-m "slow and requires_weights"``) where the checkpoint lives.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from aminx.ebm.model import ProteinEBMModel
+from aminx.utils.aa_convert import AF_ALPHABET, af_to_mpnn
+
+# --- Checkpoint plumbing (mirrors tests/ebm/test_decoy_ranking.py) ------------
+_TEST_DATA = Path(__file__).resolve().parent.parent / "data"
+_UBIQUITIN_PDB = _TEST_DATA / "1ubq.pdb"
+_ORBAX_CHECKPOINT_DIR = Path("/tmp/proteinebm_weights/ported_jax_model")
+_REAL_CHECKPOINT_AVAILABLE = (_ORBAX_CHECKPOINT_DIR / "0" / "model").exists()
+
+# The shipped ProteinEBM-x checkpoint's own dimensions (aminx.ebm.checkpoint).
+_CKPT_TOKEN_S = 256
+_CKPT_TOKEN_Z = 128
+_CKPT_DIM_FOURIER = 256
+_CKPT_TRANSITION_LAYERS = 2
+_CKPT_DEPTH = 16
+_CKPT_HEADS = 8
+_CKPT_NUM_CONTACT = 3
+
+_PINNED_T = 0.05  # MVP noise-time target (design spec §9), same as the harnesses.
+_N_RANDOM_SHUFFLES = 24
+
+
+def _restore_ported_model() -> ProteinEBMModel:
+  import orbax.checkpoint as ocp  # noqa: PLC0415 -- dev-only import, mirrors checkpoint scripts
+
+  template = ProteinEBMModel(
+    token_s=_CKPT_TOKEN_S,
+    token_z=_CKPT_TOKEN_Z,
+    dim_fourier=_CKPT_DIM_FOURIER,
+    conditioning_transition_layers=_CKPT_TRANSITION_LAYERS,
+    transformer_depth=_CKPT_DEPTH,
+    transformer_heads=_CKPT_HEADS,
+    num_contact_embeddings=_CKPT_NUM_CONTACT,
+    key=jax.random.PRNGKey(0),
+  )
+  options = ocp.CheckpointManagerOptions(max_to_keep=1)
+  manager = ocp.CheckpointManager(
+    str(_ORBAX_CHECKPOINT_DIR),
+    options=options,
+    item_handlers={"model": ocp.PyTreeCheckpointHandler()},
+  )
+  restored = manager.restore(0, items={"model": template})
+  return restored["model"]
+
+
+def _load_native_af(pdb_name: str) -> tuple[jax.Array, jax.Array, jax.Array]:
+  """Parse a local PDB into (scaled CA coords, AF-order aatype, mask).
+
+  ``parse_structure`` emits ``Protein.aatype`` in AF order -- the exact order
+  ``sequence_embedding`` expects -- so NO alphabet remap is applied here (the
+  correct path). See ``tests/ebm/test_decoy_ranking.py::_load_ca_structure``.
+  """
+  from aminx.ebm.diffusion import DEFAULT_COORDINATE_SCALING  # noqa: PLC0415
+  from aminx.io.parsing import parse_structure  # noqa: PLC0415 -- heavy import, keep lazy
+  from proxide.chem.residues import atom_order  # noqa: PLC0415
+
+  protein = parse_structure(str(_TEST_DATA / pdb_name))
+  ca_angstrom = np.asarray(protein.coordinates[:, atom_order["CA"], :], dtype=np.float32)
+  coords_scaled = jnp.asarray(ca_angstrom * DEFAULT_COORDINATE_SCALING)
+  aatype_af = jnp.asarray(np.asarray(protein.aatype, dtype=np.int32))
+  mask = jnp.asarray(np.asarray(protein.mask, dtype=bool))
+  return coords_scaled, aatype_af, mask
+
+
+@pytest.mark.slow
+@pytest.mark.requires_weights
+@pytest.mark.alphabet_boundary
+@pytest.mark.skipif(
+  not _REAL_CHECKPOINT_AVAILABLE,
+  reason=(
+    f"Real E3.5-ported orbax checkpoint not found at {_ORBAX_CHECKPOINT_DIR} "
+    "(not committed; see scripts/ebm/checkpoint_parity_check.py)."
+  ),
+)
+class TestEbmConsumesAfAlphabet:
+  """On real weights, the EBM must prefer the AF-order native sequence.
+
+  Reproduces the PR #130 bug (``af_to_mpnn(native)`` fed to the AF-ordered
+  embedding) and asserts the trained model's native-sequence preference is
+  present under AF-order and destroyed under MPNN-order.
+  """
+
+  @pytest.fixture(scope="class")
+  def model(self) -> ProteinEBMModel:
+    return _restore_ported_model()
+
+  @pytest.fixture(scope="class")
+  def native(self) -> tuple[jax.Array, jax.Array, jax.Array]:
+    return _load_native_af("1ubq.pdb")
+
+  def _energy(
+    self,
+    model: ProteinEBMModel,
+    coords: jax.Array,
+    aatype: jax.Array,
+    mask: jax.Array,
+  ) -> float:
+    # contacts=None now resolves to the reference default (ones for num=3) via
+    # trunk_features -- the Track-B change; the discrimination is unaffected by
+    # the constant contact row, since it is identical across all sequences here.
+    return float(model.energy(coords, aatype, jnp.asarray(_PINNED_T), mask))
+
+  def test_native_af_scores_lower_than_wrong_alphabet_and_random(
+    self,
+    model: ProteinEBMModel,
+    native: tuple[jax.Array, jax.Array, jax.Array],
+    capsys: pytest.CaptureFixture[str],
+  ) -> None:
+    coords, aatype_af, mask = native
+
+    # Correct convention: AF-order native (what parse_structure emits).
+    e_af = self._energy(model, coords, aatype_af, mask)
+
+    # The exact PR #130 bug: MPNN-ordered indices fed to the AF-ordered table.
+    # af_to_mpnn re-labels each residue, i.e. a fixed permutation of the native
+    # sequence -- a different (non-native) sequence on the same backbone.
+    aatype_wrong = jnp.asarray(af_to_mpnn(aatype_af), dtype=jnp.int32)
+    e_wrong = self._energy(model, coords, aatype_wrong, mask)
+
+    # Random-shuffle null distribution: permute the native residue labels.
+    rng = np.random.default_rng(0)
+    native_np = np.asarray(aatype_af)
+    e_random = np.array(
+      [
+        self._energy(model, coords, jnp.asarray(rng.permutation(native_np), dtype=jnp.int32), mask)
+        for _ in range(_N_RANDOM_SHUFFLES)
+      ],
+    )
+
+    # Diagnostic (printed, not a hidden gate) -- mirrors the neighbouring
+    # real-checkpoint tests that document observed numbers for transparency.
+    rand_mean = float(e_random.mean())
+    rand_std = float(e_random.std())
+    z_native = (e_af - rand_mean) / rand_std if rand_std > 0 else float("nan")
+    z_wrong = (e_wrong - rand_mean) / rand_std if rand_std > 0 else float("nan")
+    with capsys.disabled():
+      print(
+        f"\n[alphabet_boundary/ebm] E(native AF)={e_af:.4f}  "
+        f"E(wrong MPNN)={e_wrong:.4f}  random μ={rand_mean:.4f} σ={rand_std:.4f}  "
+        f"z_native={z_native:+.2f}  z_wrong={z_wrong:+.2f}  "
+        f"rand_frac_below_native={float((e_random < e_af).mean()):.3f}",
+      )
+
+    # (1) Reproduce-the-bug discrimination: the correct AF-order native must
+    #     score strictly lower than the mis-ordered (PR #130) sequence.
+    assert e_af < e_wrong, (
+      f"AF-order native energy {e_af:.4f} is not below the wrong-alphabet "
+      f"energy {e_wrong:.4f} -- the EBM is not consuming AF-order as required."
+    )
+
+    # (2) Native preference: the AF-order native must sit in the low tail of the
+    #     random-shuffle null (a trained EBM prefers the native sequence). A
+    #     conservative gate -- native below the 25th percentile of randoms --
+    #     rules out a degenerate/alphabet-blind pipeline without being fragile.
+    assert e_af < float(np.percentile(e_random, 25.0)), (
+      f"AF-order native energy {e_af:.4f} is not in the low quartile of the "
+      f"random-shuffle null (25th pct = {np.percentile(e_random, 25.0):.4f}); "
+      "the model shows no native-sequence preference under AF-order."
+    )
+
+    # (3) Assert-wrong-fails: the mis-ordered sequence must NOT be preferred --
+    #     it should look like a random shuffle, not a native-low outlier.
+    assert e_wrong >= float(np.percentile(e_random, 25.0)), (
+      f"wrong-alphabet energy {e_wrong:.4f} landed in the native-low quartile "
+      f"(25th pct = {np.percentile(e_random, 25.0):.4f}); the discriminator is "
+      "not separating AF-order from MPNN-order -- investigate before trusting."
+    )
+
+  def test_af_alphabet_decodes_native_ubiquitin_prefix(
+    self,
+    native: tuple[jax.Array, jax.Array, jax.Array],
+  ) -> None:
+    """Cross-check that the parsed AF-order aatype really is the native sequence.
+
+    Guards the premise of the discrimination test above: decoding the AF-order
+    aatype via ``AF_ALPHABET`` must reproduce ubiquitin's known N-terminal
+    sequence (``MQIFVK...``). If ``parse_structure`` ever silently changed
+    convention, this fails loudly instead of quietly weakening test (1)-(3).
+    """
+    _coords, aatype_af, _mask = native
+    decoded = "".join(AF_ALPHABET[int(i)] for i in np.asarray(aatype_af)[:6])
+    assert decoded == "MQIFVK", f"expected ubiquitin prefix MQIFVK, decoded {decoded!r}"

--- a/tests/ebm/test_alphabet_boundary_ebm.py
+++ b/tests/ebm/test_alphabet_boundary_ebm.py
@@ -36,6 +36,7 @@ explicitly (``-m "slow and requires_weights"``) where the checkpoint lives.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import jax
@@ -46,11 +47,19 @@ import pytest
 from aminx.ebm.model import ProteinEBMModel
 from aminx.utils.aa_convert import AF_ALPHABET, af_to_mpnn
 
-# --- Checkpoint plumbing (mirrors tests/ebm/test_decoy_ranking.py) ------------
+# --- Checkpoint plumbing -----------------------------------------------------
+# The orbax checkpoint dir is env-overridable so this can run wherever the real
+# checkpoint lives -- locally (/tmp default) or on the cluster (scratch), e.g.
+# AMINX_EBM_ORBAX_CHECKPOINT=/orcd/scratch/.../proteinebm_accuracy/orbax_model.
 _TEST_DATA = Path(__file__).resolve().parent.parent / "data"
 _UBIQUITIN_PDB = _TEST_DATA / "1ubq.pdb"
-_ORBAX_CHECKPOINT_DIR = Path("/tmp/proteinebm_weights/ported_jax_model")
-_REAL_CHECKPOINT_AVAILABLE = (_ORBAX_CHECKPOINT_DIR / "0" / "model").exists()
+_ORBAX_CHECKPOINT_DIR = Path(
+  os.environ.get("AMINX_EBM_ORBAX_CHECKPOINT", "/tmp/proteinebm_weights/ported_jax_model"),
+)
+# Available if the manager dir exists and holds at least one step subdirectory.
+_REAL_CHECKPOINT_AVAILABLE = _ORBAX_CHECKPOINT_DIR.exists() and any(
+  child.name.isdigit() for child in _ORBAX_CHECKPOINT_DIR.iterdir()
+)
 
 # The shipped ProteinEBM-x checkpoint's own dimensions (aminx.ebm.checkpoint).
 _CKPT_TOKEN_S = 256
@@ -78,13 +87,24 @@ def _restore_ported_model() -> ProteinEBMModel:
     num_contact_embeddings=_CKPT_NUM_CONTACT,
     key=jax.random.PRNGKey(0),
   )
-  options = ocp.CheckpointManagerOptions(max_to_keep=1)
   manager = ocp.CheckpointManager(
-    str(_ORBAX_CHECKPOINT_DIR),
-    options=options,
+    _ORBAX_CHECKPOINT_DIR.resolve(),
+    options=ocp.CheckpointManagerOptions(max_to_keep=1),
     item_handlers={"model": ocp.PyTreeCheckpointHandler()},
   )
-  restored = manager.restore(0, items={"model": template})
+  step = manager.latest_step()
+  if step is None:
+    msg = f"No orbax checkpoint found under {_ORBAX_CHECKPOINT_DIR}"
+    raise FileNotFoundError(msg)
+  # Current orbax requires explicit per-leaf sharding on restore (the legacy
+  # ``items=`` path leaves it None and raises "sharding ... Got None"). Derive
+  # it from the concrete template arrays via construct_restore_args -- the exact
+  # pattern scripts/ebm/real_decoy_ranking_benchmark.py::_restore_model uses.
+  restore_args = ocp.checkpoint_utils.construct_restore_args(template)
+  restored = manager.restore(
+    step,
+    args=ocp.args.Composite(model=ocp.args.PyTreeRestore(item=template, restore_args=restore_args)),
+  )
   return restored["model"]
 
 

--- a/tests/ebm/test_conformational_biasing.py
+++ b/tests/ebm/test_conformational_biasing.py
@@ -25,7 +25,12 @@ from aminx.ebm.conformational_biasing import (
 )
 from aminx.ebm.dispatch import score_state_difference
 from aminx.ebm.model import ProteinEBMModel
-from aminx.utils.aa_convert import AF_ALPHABET
+from aminx.utils.aa_convert import (
+  AF_ALPHABET,
+  MPNN_ALPHABET,
+  af_to_mpnn,
+  string_to_protein_sequence,
+)
 
 TOKEN_S = 16
 TOKEN_Z = 8
@@ -126,6 +131,48 @@ class TestSequenceToAfAatype:
   def test_raises_on_empty_sequence(self) -> None:
     with pytest.raises(ValueError, match="non-empty"):
       sequence_to_af_aatype("")
+
+  # --- Always-on alphabet-contract invariants (no weights) ------------------
+  # These lock the EBM string->aatype convention so a future refactor that
+  # swaps sequence_to_af_aatype for the MPNN-order string_to_protein_sequence
+  # (the PR #130 bug class) fails loudly in default CI, not silently on the
+  # cluster. Complements the weighted golden test in
+  # tests/ebm/test_alphabet_boundary_ebm.py.
+
+  def test_round_trips_through_af_alphabet(self) -> None:
+    # Decoding sequence_to_af_aatype's output with AF_ALPHABET must reproduce
+    # the input exactly -- i.e. it truly targets AF order, not MPNN order.
+    seq = "MQIFVKTLTGKTITLEV"  # ubiquitin N-terminal prefix, all standard residues
+    aatype = np.asarray(sequence_to_af_aatype(seq))
+    decoded = "".join(AF_ALPHABET[int(i)] for i in aatype)
+    assert decoded == seq
+
+  def test_differs_from_mpnn_converter_on_discriminating_residues(self) -> None:
+    # C and D land on different rows in the two alphabets (AF: C=4, D=3;
+    # MPNN: C=1, D=2). sequence_to_af_aatype (AF) and string_to_protein_sequence
+    # (MPNN default) MUST disagree here -- proving they are not interchangeable.
+    af = np.asarray(sequence_to_af_aatype("CD"))
+    mpnn = np.asarray(string_to_protein_sequence("CD"))
+    assert int(af[0]) == AF_ALPHABET.index("C")
+    assert int(af[1]) == AF_ALPHABET.index("D")
+    assert int(mpnn[0]) == MPNN_ALPHABET.index("C")
+    assert int(mpnn[1]) == MPNN_ALPHABET.index("D")
+    assert not np.array_equal(af, mpnn), (
+      "sequence_to_af_aatype and string_to_protein_sequence produced identical "
+      "indices on C/D -- an AF/MPNN alphabet confusion has crept back in."
+    )
+
+  def test_af_then_af_to_mpnn_matches_mpnn_converter(self) -> None:
+    # Locks the harness round-trip contract: converting the AF-order aatype
+    # back to MPNN order (af_to_mpnn) must equal the MPNN-order converter's
+    # output. This pins that AF_ALPHABET and the MPNN converter's base ordering
+    # stay mutually consistent (the assumption the two accuracy harnesses rely
+    # on when they round-trip via protein_sequence_to_string).
+    seq = "MQIFVKTLTGK"  # standard residues only
+    af = sequence_to_af_aatype(seq)
+    round_tripped = np.asarray(af_to_mpnn(af))
+    mpnn_direct = np.asarray(string_to_protein_sequence(seq))
+    np.testing.assert_array_equal(round_tripped, mpnn_direct)
 
 
 class TestScoreConformationalBias:

--- a/tests/ebm/test_model.py
+++ b/tests/ebm/test_model.py
@@ -199,8 +199,28 @@ class TestSelfConditioningDefaultFallback:
     assert not jnp.allclose(out_zero_sc, out_nonzero_sc, atol=1e-4)
 
 
+def _make_model_num_contacts(key: jax.Array, num_contact_embeddings: int) -> ProteinEBMModel:
+  return ProteinEBMModel(
+    token_s=TOKEN_S,
+    token_z=TOKEN_Z,
+    dim_fourier=12,
+    conditioning_transition_layers=1,
+    transformer_depth=DEPTH,
+    transformer_heads=HEADS,
+    num_contact_embeddings=num_contact_embeddings,
+    key=key,
+  )
+
+
 class TestContactsDefaultFallback:
-  def test_contacts_none_matches_explicit_zeros(self) -> None:
+  """The ``contacts=None`` default must match the reference (``ebm.py:167-169``):
+  all-zeros for the 2-way variant, all-ones for the 3-way variant the shipped
+  checkpoint uses. Locking both directions guards the PR #130-adjacent footgun
+  where callers had to pass ``contacts=ones`` explicitly to be reference-faithful.
+  """
+
+  def test_contacts_none_matches_explicit_zeros_when_two_way(self) -> None:
+    # Default num_contact_embeddings == 2 -> "no external contact" -> zeros.
     key = jax.random.PRNGKey(25)
     model = _make_model(key)
     coords, aatype, mask, t = _synthetic_inputs(jax.random.PRNGKey(26))
@@ -210,6 +230,23 @@ class TestContactsDefaultFallback:
       coords, aatype, t, mask, contacts=jnp.zeros((N,), dtype=jnp.int32)
     )
     assert jnp.array_equal(out_default, out_explicit_zeros)
+
+  def test_contacts_none_matches_explicit_ones_when_three_way(self) -> None:
+    # num_contact_embeddings == 3 -> reference defaults external_contacts to ones.
+    key = jax.random.PRNGKey(125)
+    model = _make_model_num_contacts(key, num_contact_embeddings=3)
+    coords, aatype, mask, t = _synthetic_inputs(jax.random.PRNGKey(126))
+
+    out_default = model.trunk_features(coords, aatype, t, mask, contacts=None)
+    out_explicit_ones = model.trunk_features(
+      coords, aatype, t, mask, contacts=jnp.ones((N,), dtype=jnp.int32)
+    )
+    out_explicit_zeros = model.trunk_features(
+      coords, aatype, t, mask, contacts=jnp.zeros((N,), dtype=jnp.int32)
+    )
+    assert jnp.array_equal(out_default, out_explicit_ones)
+    # And it must NOT silently fall back to zeros on the 3-way variant.
+    assert not jnp.allclose(out_default, out_explicit_zeros, atol=1e-5)
 
 
 class TestJitCompatibility:


### PR DESCRIPTION
## Context

Follow-up to #130 (which fixed a ~2-day ProteinEBM accuracy regression). Both defects that caused it survived because the guardrails validated the wrong thing: the numerical parity gate feeds identical *random* ints to both implementations (alphabet-agnostic by construction), and every EBM test used random ints, all-zeros, or asserted *no* accuracy. This PR makes the reference-faithful eval path the **enforced default** so neither bug class can recur silently.

## Track A — alphabet guardrail

The `sequence_embedding` lookup is a direct row lookup with no ordering conversion — the PR #130 bug fed ProteinMPNN-ordered indices to the AF2-ordered table.

- **New weighted golden test** `tests/ebm/test_alphabet_boundary_ebm.py`: on real weights, the EBM must prefer the AF-order native sequence (lower energy) over `af_to_mpnn(native)` (the exact bug) and over random shuffles — the "assert-correct AND assert-wrong-fails" discrimination pattern. Chosen because sequence-preference-at-fixed-structure is the only signal that actually collapses under a scrambled alphabet (energy-vs-RMSD and disruptive-vs-conservative ddG both *survive* it, so they can't discriminate). Marked `slow`/`requires_weights`/`alphabet_boundary`; skips when the checkpoint is absent.
- **Always-on conversion invariants** (no weights, runs in CI) in `test_conformational_biasing.py`: `sequence_to_af_aatype` round-trips through `AF_ALPHABET`, differs from the MPNN-order `string_to_protein_sequence` on discriminating residues, and its `af_to_mpnn` image matches the MPNN converter — trips immediately if the two converters are ever swapped.
- **Pinned "EBM consumes AF-order" in code**: the `InputEmbeddings` lookup docstring and a corrected `ddg_stability.py` module docstring (its CA loader / mutant helpers still emit MPNN order and must be converted before reaching `model.energy`).

## Track B — `contacts=ones` default for the num=3 checkpoint (trunk change)

- `ProteinEBMModel.trunk_features` now resolves `contacts=None` to all-**ones** when `num_contact_embeddings == 3` (read from the contact embedding table), all-zeros otherwise — matching the reference (`ebm.py:167-169`). Single defaulting choke point, so `energy`/`score`/`aux_score` all inherit it; callers no longer need to pass `contacts=ones` by hand.
- `test_model.py::TestContactsDefaultFallback` extended with the num=3 → ones case.
- `checkpoint_parity_check.py`: added a `contacts=None` default-parity case proving the JAX/PyTorch defaults now agree (guarded so a reference-API mismatch warns rather than breaking the explicit-zeros parity).
- The two accuracy harnesses' explicit `contacts=ones` are now redundant; kept as defensive, self-documenting pins.

## Verification

- ✅ `ruff check` + `ruff format --check` + `ty check` pass.
- ✅ No-weights tests pass locally (8 passed: contacts num=2/num=3, conversion invariants).
- ⏳ **Needs a cluster run** (checkpoint not present locally): the weighted A1 discrimination test and the `contacts=None` parity case — both import cleanly and skip correctly without weights. On first weighted run, confirm the A1 quartile thresholds hold and tune if needed (documented in the test).
- Regression smoke: the two harnesses pass explicit ones and are behavior-invariant to Track B, so PR #130 numbers (decoy ~0.83, ddG ~0.68) should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)