### PR TITLE
fix(host): sidechain_conditioning implies use_side_chain_context (silent no-op)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a21"
+version = "0.1.0a22"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [

--- a/src/aminx/host/prep.py
+++ b/src/aminx/host/prep.py
@@ -146,8 +146,36 @@ def prep_protein_stream_and_model(
   # now fails loudly. That is the correct outcome: it is what "I asked for electrostatics"
   # should do when the checkpoint cannot provide them. Silently ignoring the request is the
   # bug being fixed.
+  #
+  # sidechain_conditioning IMPLIES use_side_chain_context. These are two different
+  # switches for one capability: sidechain_conditioning makes _sampling_helper build
+  # and pass the atom_37 sidechain context, while use_side_chain_context is what
+  # actually BUILDS the model branch that consumes it. Requesting the former while
+  # leaving the latter unset (None -> False) fed real sidechain context to a model
+  # that structurally ignored it -- a silent no-op, the same declared-but-never-
+  # delivered class as the bug the comment above describes. Confirmed empirically
+  # 2026-07-28: with sidechain_conditioning=True and the ctx flag None, AR-decode
+  # logits were BIT-IDENTICAL to sidechain_conditioning=False (max|diff|=0.0); with
+  # the ctx flag set, the same context moved them (max|diff|=2.47). This silently
+  # invalidated the SC arms of a whole tev_design campaign (its "SC conditioning is
+  # inert" conclusion was measuring a no-op, not the feature).
+  #
+  # An explicit `ligand_mpnn_use_side_chain_context=False` alongside
+  # sidechain_conditioning=True is contradictory, so it raises rather than silently
+  # picking one -- never resolve a contradiction by guessing.
+  if spec.sidechain_conditioning and spec.ligand_mpnn_use_side_chain_context is False:
+    msg = (
+      "sidechain_conditioning=True with ligand_mpnn_use_side_chain_context=False is "
+      "contradictory: the sidechain context would be built and passed, but the model "
+      "would be built without the branch that consumes it (a silent no-op). Set "
+      "ligand_mpnn_use_side_chain_context=True (or leave it unset to have it implied), "
+      "or set sidechain_conditioning=False."
+    )
+    raise ValueError(msg)
+
   model_conditioning = {
-    "use_side_chain_context": bool(spec.ligand_mpnn_use_side_chain_context),
+    "use_side_chain_context": bool(spec.ligand_mpnn_use_side_chain_context)
+    or bool(spec.sidechain_conditioning),
     "use_electrostatics": bool(spec.use_electrostatics),
     "use_vdw": bool(spec.use_vdw),
   }

--- a/tests/host/test_prep_sidechain_coupling.py
+++ b/tests/host/test_prep_sidechain_coupling.py
@@ -1,0 +1,84 @@
+"""Tests that sidechain_conditioning implies use_side_chain_context in prep.py.
+
+Regression guard for a silent no-op: `sidechain_conditioning` makes
+_sampling_helper build and pass the atom_37 sidechain context, but
+`ligand_mpnn_use_side_chain_context` is what BUILDS the model branch that
+consumes it. Requesting the former while leaving the latter unset (None ->
+False) fed real sidechain context to a model that structurally ignored it.
+Confirmed empirically 2026-07-28: AR-decode logits were bit-identical to
+sidechain_conditioning=False (max|diff|=0.0) until the ctx flag was set, at
+which point the same context moved them (max|diff|=2.47).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aminx.host.prep import prep_protein_stream_and_model
+from aminx.run.specs import SamplingSpecification
+
+
+def _use_side_chain_context_passed_to_load_model(spec: SamplingSpecification) -> bool:
+  """Run prep with load_model mocked; return the use_side_chain_context kwarg it got."""
+  with patch("aminx.host.prep.create_protein_dataset") as mock_dataset, \
+       patch("aminx.host.prep.load_model") as mock_load_model:
+    mock_dataset.return_value = MagicMock()
+    mock_load_model.return_value = MagicMock()
+    try:
+      prep_protein_stream_and_model(spec)
+    except Exception:  # noqa: BLE001 - downstream mocking raises; we only need the call
+      pass
+    assert mock_load_model.called, "load_model was never called"
+    return bool(mock_load_model.call_args.kwargs["use_side_chain_context"])
+
+
+class TestSidechainConditioningImpliesContext:
+  """sidechain_conditioning=True must build the sidechain branch."""
+
+  def test_sidechain_conditioning_alone_implies_context(self) -> None:
+    """THE REGRESSION: sc=True with the ctx flag unset must still build the branch."""
+    spec = SamplingSpecification(
+      inputs="dummy.pdb",
+      sidechain_conditioning=True,
+      # ligand_mpnn_use_side_chain_context left unset (None) -- the campaign's config
+    )
+    assert spec.ligand_mpnn_use_side_chain_context is None
+    assert _use_side_chain_context_passed_to_load_model(spec) is True
+
+  def test_explicit_context_flag_still_honored(self) -> None:
+    """Setting the ctx flag explicitly (without sc) keeps working as before."""
+    spec = SamplingSpecification(
+      inputs="dummy.pdb",
+      ligand_mpnn_use_side_chain_context=True,
+    )
+    assert _use_side_chain_context_passed_to_load_model(spec) is True
+
+  def test_both_flags_set_is_fine(self) -> None:
+    spec = SamplingSpecification(
+      inputs="dummy.pdb",
+      sidechain_conditioning=True,
+      ligand_mpnn_use_side_chain_context=True,
+    )
+    assert _use_side_chain_context_passed_to_load_model(spec) is True
+
+  def test_neither_flag_leaves_branch_off(self) -> None:
+    """No sidechain request -> model built without the branch (unchanged default)."""
+    spec = SamplingSpecification(inputs="dummy.pdb")
+    assert _use_side_chain_context_passed_to_load_model(spec) is False
+
+  def test_contradictory_flags_raise(self) -> None:
+    """sc=True with ctx explicitly False is contradictory -- raise, don't guess."""
+    spec = SamplingSpecification(
+      inputs="dummy.pdb",
+      sidechain_conditioning=True,
+      ligand_mpnn_use_side_chain_context=False,
+    )
+    with patch("aminx.host.prep.create_protein_dataset") as mock_dataset, \
+         patch("aminx.host.prep.load_model") as mock_load_model:
+      mock_dataset.return_value = MagicMock()
+      mock_load_model.return_value = MagicMock()
+      with pytest.raises(ValueError, match="contradictory"):
+        prep_protein_stream_and_model(spec)
+      assert not mock_load_model.called, "must raise before building the model"


### PR DESCRIPTION
## The bug

`sidechain_conditioning` and `ligand_mpnn_use_side_chain_context` are **two switches for one capability**:

- `sidechain_conditioning=True` → `_sampling_helper` builds and passes the `atom_37` sidechain context (of the fixed residues).
- `ligand_mpnn_use_side_chain_context` → `prep.py` → `load_model` → **builds the model branch that consumes it**.

Setting only the first (leaving the second `None` → `bool(None)` → `False`) fed real sidechain context to a model built **without** the branch, which structurally ignored it — **no error, no warning**. This is the same declared-but-never-delivered class that `prep.py`'s own comment already documents (occurrences #6/#11); it just wasn't closed for the `sidechain_conditioning` entry point.

## Empirical confirmation (AR decode path, 1LVB, fixed catalytic triad, seed 42, T=0.1)

| config | vs `sidechain_conditioning=False` | |
|---|---|---|
| **before** — `sc=True`, ctx `None` | `max|diff| = 0.0` | **bit-identical → no-op** |
| **before** — `sc=True`, ctx `True` | `max|diff| = 2.47` | works |
| **after** — `sc=True`, ctx `None` | `max|diff| = 2.69` | works ✅ |
| **after** — `sc=True`, ctx `None` vs explicit ctx `True` | `max|diff| = 0.0` | implication exact ✅ |

## Why it matters

This silently invalidated the sidechain-conditioned arms of a downstream **tev_design** campaign. Its conclusion — "SC conditioning is inert on the AR path" — was measuring the no-op, not the feature. Any caller that set only `sidechain_conditioning` got backbone-only behaviour under an SC label, and the discrepancy against the teacher-forced path (which calls `load_model(use_side_chain_context=...)` directly and was correctly wired) looked like a mechanism difference rather than a bug.

## The fix

`use_side_chain_context = bool(ctx_flag) or bool(sidechain_conditioning)` — requesting sidechain conditioning implies building the branch. An explicit `ligand_mpnn_use_side_chain_context=False` alongside `sidechain_conditioning=True` is contradictory and now **raises** rather than silently picking one.

## Tests

`tests/host/test_prep_sidechain_coupling.py` — 5 cases: the regression (sc alone implies ctx), explicit ctx still honored, both set, neither set (default unchanged), contradictory flags raise before model construction. **8 passed** with the existing `test_prep_cache.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)