### PR TITLE
fix(inference): AR decode must honor multi_state_strategy, state_weights and temperature

### DIFF
--- a/src/aminx/host/plan.py
+++ b/src/aminx/host/plan.py
@@ -872,8 +872,11 @@ def make_inference_plan(
      ``use_rolling_state=True`` selects scan-based multi-state encoding; False uses vmap.
   2. ``logit_transform`` — instantiated from ``LOGIT_STRATEGIES[multi_state_strategy]``
      with ``state_weights`` and ``multi_state_temperature``.
-  3. ``ar_logit_transform`` — always wired as ``ARLogitFuse()`` (arithmetic mean + bias
-     injection over states, identity when S=1).
+  3. ``ar_logit_transform`` — the SAME instance as ``logit_transform`` (step 2), so the
+     autoregressive path honours ``multi_state_strategy``, ``state_weights`` and
+     ``multi_state_temperature`` identically to the non-AR path; identity when S=1.
+     Until 2026-07-28 this was hardcoded to ``ARLogitFuse()`` (unweighted arithmetic
+     mean), which silently discarded all three on the AR path.
   4. ``tie_group_fuse`` — always wired as ``TieGroupProductOfExperts()`` (log-softmax sum
      across tied positions).
   5. ``decode_step`` and ``sample_step`` — for ``sampling_strategy="straight_through"``,

--- a/src/aminx/inference/logits.py
+++ b/src/aminx/inference/logits.py
@@ -403,6 +403,9 @@ def make_stage_set(
   -------
   StageSet
       Stage set with logit_transform, ar_logit_transform, and tie_group_fuse wired.
+      ``ar_logit_transform`` is the SAME instance as ``logit_transform``, so the
+      autoregressive path honours ``strategy``, ``state_weights`` and
+      ``strategy_temperature`` identically to the non-AR path.
 
   """
   from aminx.types.stages import StageSet
@@ -425,7 +428,29 @@ def make_stage_set(
 
   return StageSet(
     logit_transform=logit_transform,
-    ar_logit_transform=ARLogitFuse(),
+    # AR decode fuses with the SAME configured instance, not a hardcoded mean.
+    #
+    # This slot used to be `ARLogitFuse()` -- constructed with no strategy and no
+    # weights, so its body (`jnp.mean(logits, axis=0) + bias`) silently overrode
+    # BOTH `strategy` and `state_weights` on the autoregressive path. Callers
+    # asking for `multi_state_strategy="product"` with non-uniform
+    # `state_weights` got an unweighted arithmetic mean and no error, while the
+    # manifest recorded the requested strategy. Weighted product-of-experts
+    # fusion therefore did not exist on the AR path at all, and a zero weight
+    # did NOT drop its state (under a plain mean it contributes like any other).
+    # `strategy_temperature` was lost the same way.
+    #
+    # Reusing the one instance -- rather than building a second strategy-aware AR
+    # fuser -- is deliberate: it makes AR and non-AR fusion identical BY
+    # CONSTRUCTION, so the two can never drift apart again. The strategy classes
+    # are typed `Float[Array, "S ... V"]` with an optional trailing `bias`, which
+    # is exactly the `(S, V) + (V,) -> (V,)` contract the AR kernel calls with,
+    # so no adapter is needed.
+    #
+    # `ARLogitFuse` is kept and still exported: it remains the correct explicit
+    # choice for an intentionally unweighted mean. It is simply no longer
+    # substituted for whatever the caller actually configured.
+    ar_logit_transform=logit_transform,
     decode_step=None,
     sample_step=None,
     tie_group_fuse=TieGroupProductOfExperts(),

--- a/tests/inference/test_ar_fusion_honors_strategy.py
+++ b/tests/inference/test_ar_fusion_honors_strategy.py
@@ -1,0 +1,144 @@
+"""The AR path must honour multi_state_strategy, state_weights and temperature.
+
+Regression tests for the 2026-07-28 finding that `make_stage_set` wired
+`ar_logit_transform=ARLogitFuse()` -- constructed with no strategy and no weights --
+so the autoregressive decode fused states with a hardcoded unweighted
+`jnp.mean(logits, axis=0) + bias`. Callers asking for `"product"` fusion with
+non-uniform `state_weights` silently got an unweighted arithmetic mean, and the
+manifest recorded the strategy they asked for. Weighted product-of-experts fusion
+did not exist on the AR path.
+
+WHY THESE TESTS, AND NOT THE EXISTING KNOB HARNESS.
+`tests/host/test_knob_differential.py` asserts *reachability*: does knob X arrive
+at consumer Y. Both `multi_state_strategy` and `state_weights` DID arrive -- at
+`make_stage_set`, which then used them for one of its two output slots. A
+reachability harness cannot see a knob that reaches its consumer and is dropped on
+one of two code paths. These tests are *path-aware*: they assert the AR slot
+responds, and that the two slots agree.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from aminx.inference.logits import ARLogitFuse, make_stage_set
+
+S, V = 3, 21
+
+
+def _per_state() -> jnp.ndarray:
+  rng = np.random.default_rng(0)
+  return jnp.asarray(rng.normal(size=(S, V)).astype("float32"))
+
+
+def _bias() -> jnp.ndarray:
+  return jnp.zeros((V,), dtype=jnp.float32)
+
+
+UNIFORM = jnp.asarray([1 / 3, 1 / 3, 1 / 3], dtype=jnp.float32)
+SKEWED = jnp.asarray([0.90, 0.05, 0.05], dtype=jnp.float32)
+FIRST_ONLY = jnp.asarray([1.0, 0.0, 0.0], dtype=jnp.float32)
+
+
+@pytest.mark.parametrize("strategy", ["arithmetic_mean", "geometric_mean", "product"])
+def test_ar_transform_responds_to_state_weights(strategy: str) -> None:
+  """THE REGRESSION. Changing state_weights must change AR-fused logits.
+
+  Fails on the pre-fix wiring for every strategy: ARLogitFuse ignored weights
+  entirely, so uniform and skewed produced bit-identical output.
+  """
+  per_state, bias = _per_state(), _bias()
+  uni = make_stage_set(strategy=strategy, state_weights=UNIFORM).ar_logit_transform(per_state, bias)
+  skew = make_stage_set(strategy=strategy, state_weights=SKEWED).ar_logit_transform(per_state, bias)
+  assert not np.allclose(np.asarray(uni), np.asarray(skew), atol=1e-6), (
+    f"AR fusion ignored state_weights for strategy={strategy!r} -- weighted "
+    "product-of-experts is not reaching the autoregressive decode."
+  )
+
+
+def test_ar_transform_responds_to_strategy() -> None:
+  """Changing multi_state_strategy must change AR-fused logits."""
+  per_state, bias = _per_state(), _bias()
+  outs = {
+    s: np.asarray(make_stage_set(strategy=s, state_weights=UNIFORM).ar_logit_transform(per_state, bias))
+    for s in ("arithmetic_mean", "geometric_mean", "product")
+  }
+  assert not np.allclose(outs["product"], outs["arithmetic_mean"], atol=1e-6), (
+    "AR fusion ignored multi_state_strategy: 'product' matched 'arithmetic_mean'."
+  )
+
+
+def test_ar_transform_respects_strategy_temperature() -> None:
+  """strategy_temperature must reach the AR path (geometric_mean consumes it).
+
+  Also pins the DIRECTION: smaller temperature sharpens. Guards against a
+  temperature-inversion regression, where a plausible-looking change flips the
+  convention and silently uniformises every distribution.
+  """
+  bias = _bias()
+  sharp = jnp.asarray(np.tile((np.eye(1, V, 0) * 10.0), (S, 1)).astype("float32"))
+
+  def peak(temp: float) -> float:
+    out = make_stage_set(
+      strategy="geometric_mean", strategy_temperature=temp, state_weights=UNIFORM,
+    ).ar_logit_transform(sharp, bias)
+    shifted = out - jnp.max(out)
+    probs = jnp.exp(shifted) / jnp.sum(jnp.exp(shifted))
+    return float(jnp.max(probs))
+
+  hot, cold = peak(10.0), peak(0.1)
+  assert cold > hot, f"temperature had no effect on AR path (cold={cold}, hot={hot})"
+  assert cold > 0.9, f"small temperature must SHARPEN; got peak prob {cold} (convention inverted?)"
+  assert hot < 0.5, f"large temperature must FLATTEN; got peak prob {hot} (convention inverted?)"
+
+
+@pytest.mark.parametrize("strategy", ["arithmetic_mean", "geometric_mean", "product"])
+def test_zero_weight_drops_its_state_on_ar_path(strategy: str) -> None:
+  """A zero-weighted state must not contribute to AR fusion.
+
+  tev_design's k=9 weight variants rely on this: profiles like
+  ``crystal_only=[1,1,0,0,0,0,0,0,0]`` express "use only these states" as zero
+  weights. Under the pre-fix unweighted mean a zero-weighted state contributed
+  exactly as much as every other one, so those profiles were inert.
+  """
+  per_state, bias = _per_state(), _bias()
+  fused = make_stage_set(strategy=strategy, state_weights=FIRST_ONLY).ar_logit_transform(
+    per_state, bias,
+  )
+  np.testing.assert_allclose(
+    np.asarray(fused), np.asarray(per_state[0]), atol=1e-4,
+    err_msg=f"strategy={strategy!r}: zero-weighted states still contributed to AR fusion",
+  )
+
+
+@pytest.mark.parametrize("strategy", ["arithmetic_mean", "geometric_mean", "product"])
+def test_ar_and_non_ar_paths_agree(strategy: str) -> None:
+  """The two fusion slots must not diverge.
+
+  The original defect was precisely a divergence: `logit_transform` honoured the
+  configuration while `ar_logit_transform` did not. Asserting behavioural equality
+  keeps them pinned together even if the implementation stops sharing one instance.
+  """
+  per_state, bias = _per_state(), _bias()
+  ss = make_stage_set(strategy=strategy, state_weights=SKEWED, strategy_temperature=1.0)
+  np.testing.assert_allclose(
+    np.asarray(ss.ar_logit_transform(per_state, bias)),
+    np.asarray(ss.logit_transform(per_state, bias)),
+    atol=1e-6,
+    err_msg=f"strategy={strategy!r}: AR and non-AR fusion disagree",
+  )
+
+
+def test_arlogitfuse_still_available_as_explicit_unweighted_mean() -> None:
+  """ARLogitFuse remains valid when an unweighted mean is what you actually want.
+
+  The fix removes it as the silent DEFAULT, not as an option.
+  """
+  per_state, bias = _per_state(), _bias()
+  np.testing.assert_allclose(
+    np.asarray(ARLogitFuse()(per_state, bias)),
+    np.asarray(jnp.mean(per_state, axis=0) + bias),
+    atol=1e-6,
+  )


### PR DESCRIPTION
## The bug

`make_stage_set` wired `ar_logit_transform=ARLogitFuse()` — **constructed with no strategy and no weights** — so the autoregressive path fused states with a hardcoded, unweighted `jnp.mean(logits, axis=0) + bias`.

```python
logit_transform    = strategy_cls(weights, temperature=strategy_temperature)
ar_logit_transform = ARLogitFuse()   # ← strategy and weights both discarded
```

Callers asking for `multi_state_strategy="product"` with non-uniform `state_weights` silently got an arithmetic mean, with **no error**, while the manifest recorded the strategy they asked for. `strategy_temperature` was lost the same way. **Weighted product-of-experts fusion did not exist on the AR path at all.**

This is a recurrence of the 2026-07-15 knob audit's *"multi_state_strategy silently reverts to arithmetic_mean; manifest bookkeeping falsely records requested strategy"* — never fixed for the AR path. `host/plan.py:875` documented the broken behaviour as intended (*"always wired as `ARLogitFuse()`"*), which is a large part of why it read as settled rather than as a bug.

## The fix

`ar_logit_transform` is now the **same instance** as `logit_transform`.

The strategy classes are typed `Float[Array, "S ... V"]` with an optional trailing `bias` — exactly the `(S,V) + (V,) -> (V,)` contract the AR kernel calls with — so no adapter is needed. Sharing one instance makes the two paths identical *by construction*, so they cannot drift apart again.

`ARLogitFuse` is kept and still exported. It remains the correct explicit choice for an intentionally unweighted mean; it is simply no longer substituted for whatever the caller configured.

## Verified before writing the fix, not assumed

- All three strategies are shape-agnostic on `(S,V)` → `(V,)`, finite
- Weights change output for all three; `[1,0,0]` reduces **exactly** to state 0, so zero-weight state-dropping works once the AR path actually calls them
- **Temperature convention is correct, not inverted**: T=0.1 → peak prob 1.0000, T=10 → 0.1197 (synthetic one-hot ground truth, per the BATHOS "verify your measurement pipeline" rule)

## Tests

`tests/inference/test_ar_fusion_honors_strategy.py` — **path-aware, not reachability-based**, and confirmed to fail on the pre-fix wiring:

> reverting `ar_logit_transform` to `ARLogitFuse()` → **11 of 12 fail**. The 12th asserts `ARLogitFuse` is still an unweighted mean, which holds either way.

Coverage: weights respected (per strategy), strategy respected, temperature reaches the AR path *and* points the right direction, zero-weight state dropping, and AR/non-AR behavioural agreement.

**Why `test_knob_differential.py` could not catch this:** it asserts *knob X reaches consumer Y*. Both knobs **did** reach `make_stage_set` — which then used them for one of its two output slots. A reachability harness is structurally blind to a knob that arrives and is dropped on one of two code paths.

Local: 23 passed (new + existing AR tests), 15 passed (`test_comp533_stage_set_hoist`, `test_registry_consolidation`). Full suite left to CI — it exceeds the local JAX compute budget. Ruff on the changed `src` files is unchanged from `main` (61 = 61 pre-existing).

## Downstream impact (tev_design)

- Necklace `WEIGHT_PROFILES` `uniform` and `reaction_favored` are k=4 over the **same** inputs differing only by weights → they were **identical beads** on the AR path
- k=9 `STATE_WEIGHT_VARIANTS` expressing "use only these states" as zero weights did **not** drop those states
- Unaffected: teacher-forced scoring (`logit_transform`), STE optimization, and any single-state row (never enters fusion)

praxia debt #1069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZnG4LoEV78qTcCcCVboc5