### PR TITLE
chore: bump version 0.1.0a22 -> 0.1.0a23 (AR fusion fix, #135)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aminx"
-version = "0.1.0a22"
+version = "0.1.0a23"
 description = "Aminx: A functional interface for ProteinMPNN"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
Version bump so the AR-fusion fix from #135 ships as a distinguishable wheel.

Downstream tev_design pins the vendored wheel by filename. On `<= a22` the autoregressive path computed `mean(logits)` where `multi_state_strategy="product"` was requested — an exact factor-of-S error on the logit scale, i.e. a temperature change. Any multi-state sampled output produced with `<= a22` is not what its manifest specified, so the two wheels must not share a version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZnG4LoEV78qTcCcCVboc5